### PR TITLE
ゲームのレスポンスを改善

### DIFF
--- a/ElectronicObserver/Notifier/NotifierManager.cs
+++ b/ElectronicObserver/Notifier/NotifierManager.cs
@@ -57,7 +57,7 @@ namespace ElectronicObserver.Notifier {
 		}
 
 		public void ShowNotifier( ElectronicObserver.Window.Dialog.DialogNotifier form ) {
-			_parentForm.Invoke( (MethodInvoker)( () => form.Show() ) );
+			form.Show();
 		}
 
 	}

--- a/ElectronicObserver/Observer/APIObserver.cs
+++ b/ElectronicObserver/Observer/APIObserver.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using System.Windows.Forms;
 
 namespace ElectronicObserver.Observer {
 
@@ -34,6 +35,8 @@ namespace ElectronicObserver.Observer {
 
 		public delegate void ProxyStartedEventHandler();
 		public event ProxyStartedEventHandler ProxyStarted = delegate { };
+
+		private Control UIControl;
 
 		private APIObserver() {
 
@@ -99,10 +102,9 @@ namespace ElectronicObserver.Observer {
 
 		}
 
-
-
-
-		public int Start( int portID ) {
+		// UIControl: GUIスレッドで実行するためのオブジェクト。中身は何でもいい
+		public int Start( int portID, Control UIControl ) {
+			this.UIControl = UIControl;
 
 			Fiddler.FiddlerApplication.Startup( portID, Fiddler.FiddlerCoreStartupFlags.ChainToUpstreamGateway |
 				( Utility.Configuration.Config.Connection.RegisterAsSystemProxy ? Fiddler.FiddlerCoreStartupFlags.RegisterAsSystemProxy : 0 ) );
@@ -155,12 +157,20 @@ namespace ElectronicObserver.Observer {
 
 						if ( c.SaveResponse && oSession.fullUrl.Contains( "/kcsapi/" ) ) {
 
-							SaveResponse( oSession.fullUrl, oSession.GetResponseBodyAsString() );
+							// 非同期で書き出し処理するので取っておく
+							// stringはイミュータブルなのでOK
+							string url = oSession.fullUrl;
+							string body = oSession.GetResponseBodyAsString();
+
+							Task.Run( (Action)( () => {
+								SaveResponse( url, body );
+							} ) );
 
 						} else if ( oSession.fullUrl.Contains( "/kcs/" ) &&
 							( ( c.SaveSWF && oSession.oResponse.MIMEType == "application/x-shockwave-flash" ) || c.SaveOtherFile ) ) {
 
-							string tpath = string.Format( "{0}\\{1}", c.SaveDataPath, oSession.fullUrl.Substring( oSession.fullUrl.IndexOf( "/kcs/" ) + 5 ).Replace( "/", "\\" ) );
+							string saveDataPath = c.SaveDataPath; // スレッド間の競合を避けるため取っておく
+							string tpath = string.Format( "{0}\\{1}", saveDataPath, oSession.fullUrl.Substring( oSession.fullUrl.IndexOf( "/kcs/" ) + 5 ).Replace( "/", "\\" ) );
 							{
 								int index = tpath.IndexOf( "?" );
 								if ( index != -1 ) {
@@ -178,21 +188,32 @@ namespace ElectronicObserver.Observer {
 									tpath = tpath.Remove( index );
 								}
 							}
-							Directory.CreateDirectory( Path.GetDirectoryName( tpath ) );
 
-							//System.Diagnostics.Debug.WriteLine( oSession.fullUrl + " => " + tpath );
-							using ( var sw = new System.IO.BinaryWriter( System.IO.File.OpenWrite( tpath ) ) ) {
-								sw.Write( oSession.ResponseBody );
-							}
+							// 非同期で書き出し処理するので取っておく
+							byte[] responseCopy = new byte[oSession.ResponseBody.Length];
+							Array.Copy( oSession.ResponseBody, responseCopy, oSession.ResponseBody.Length );
 
-							Utility.Logger.Add( 1, string.Format( "通信からファイル {0} を保存しました。", tpath.Remove( 0, c.SaveDataPath.Length + 1 ) ) );
+							Task.Run( (Action)( () => {
+								try {
+									lock ( this ) {
+										// 同時に書き込みが走るとアレなのでロックしておく
 
+										Directory.CreateDirectory( Path.GetDirectoryName( tpath ) );
+
+										//System.Diagnostics.Debug.WriteLine( oSession.fullUrl + " => " + tpath );
+										using ( var sw = new System.IO.BinaryWriter( System.IO.File.OpenWrite( tpath ) ) ) {
+											sw.Write( responseCopy );
+										}
+									}
+
+									Utility.Logger.Add( 1, string.Format( "通信からファイル {0} を保存しました。", tpath.Remove( 0, saveDataPath.Length + 1 ) ) );
+
+								} catch ( IOException ex ) {	//ファイルがロックされている; 頻繁に出るのでエラーレポートを残さない
+
+									Utility.Logger.Add( 3, "通信内容の保存に失敗しました。 " + ex.Message );
+								}
+							} ) );
 						}
-
-
-					} catch ( IOException ex ) {	//ファイルがロックされている; 頻繁に出るのでエラーレポートを残さない
-
-						Utility.Logger.Add( 3, "通信内容の保存に失敗しました。 " + ex.Message );
 
 					} catch ( Exception ex ) {
 
@@ -206,7 +227,11 @@ namespace ElectronicObserver.Observer {
 
 			if ( oSession.fullUrl.Contains( "/kcsapi/" ) && oSession.oResponse.MIMEType == "text/plain" ) {
 
-				LoadResponse( oSession.fullUrl, oSession.GetResponseBodyAsString() );
+				// 非同期でGUIスレッドに渡すので取っておく
+				// stringはイミュータブルなのでOK
+				string url = oSession.fullUrl;
+				string body = oSession.GetResponseBodyAsString();
+				UIControl.BeginInvoke( (Action)( () => { LoadResponse( url, body ); } ) );
 
 			}
 
@@ -241,17 +266,20 @@ namespace ElectronicObserver.Observer {
 
 			if ( oSession.fullUrl.Contains( "/kcsapi/" ) ) {
 
+				string url = oSession.fullUrl;
+				string body = oSession.GetRequestBodyAsString();
+				
 				//保存
 				{
 					if ( c.SaveReceivedData && c.SaveRequest ) {
 
-						SaveRequest( oSession.fullUrl, oSession.GetRequestBodyAsString() );
+						Task.Run( (Action)( () => {
+							SaveResponse( url, body );
+						} ) );
 					}
 				}
 
-
-				LoadRequest( oSession.fullUrl, oSession.GetRequestBodyAsString() );
-
+				UIControl.BeginInvoke( (Action)( () => { LoadRequest( url, body ); } ) );
 			}
 
 		}

--- a/ElectronicObserver/Utility/Logger.cs
+++ b/ElectronicObserver/Utility/Logger.cs
@@ -75,7 +75,9 @@ namespace ElectronicObserver.Utility {
 
 		public static IReadOnlyList<LogData> Log {
 			get {
-				return Logger.Instance.log.AsReadOnly();
+				lock ( Logger.Instance ) {
+					return Logger.Instance.log.AsReadOnly();
+				}
 			}
 		}
 
@@ -89,7 +91,9 @@ namespace ElectronicObserver.Utility {
 
 			LogData data = new LogData( DateTime.Now, priority, message );
 
-			Logger.Instance.log.Add( data );
+			lock ( Logger.Instance ) {
+				Logger.Instance.log.Add( data );
+			}
 
 
 			if ( Configuration.Config.Log.LogLevel <= priority ) {
@@ -113,7 +117,9 @@ namespace ElectronicObserver.Utility {
 		/// ログをすべて消去します。
 		/// </summary>
 		public static void Clear() {
-			Logger.instance.log.Clear();
+			lock ( Logger.Instance ) {
+				Logger.instance.log.Clear();
+			}
 		}
 
 
@@ -125,20 +131,20 @@ namespace ElectronicObserver.Utility {
 		public static void Save( string path ) {
 
 			try {
+				lock ( Logger.Instance ) {
+					using ( StreamWriter sw = new StreamWriter( path ) ) {
 
-				using ( StreamWriter sw = new StreamWriter( path ) ) {
+						int priority = Configuration.Config.Log.LogLevel;
 
-					int priority = Configuration.Config.Log.LogLevel;
+						var list = Logger.instance.log.Where( l => l.Priority >= priority );
 
-					var list = Logger.instance.log.Where( l => l.Priority >= priority );
-
-					foreach ( var l in list ) {
-						sw.WriteLine( l.ToString() );
+						foreach ( var l in list ) {
+							sw.WriteLine( l.ToString() );
+						}
 					}
 				}
-
 			} catch ( Exception ) {
-				
+
 				// に ぎ り つ ぶ す
 			}
 

--- a/ElectronicObserver/Window/Dialog/DialogConfiguration.cs
+++ b/ElectronicObserver/Window/Dialog/DialogConfiguration.cs
@@ -335,7 +335,7 @@ namespace ElectronicObserver.Window.Dialog {
 
 				if ( changed ) {
 					APIObserver.Instance.Stop();
-					APIObserver.Instance.Start( config.Connection.Port );
+					APIObserver.Instance.Start( config.Connection.Port, this );
 				}
 			}
 

--- a/ElectronicObserver/Window/FormArsenal.cs
+++ b/ElectronicObserver/Window/FormArsenal.cs
@@ -170,13 +170,11 @@ namespace ElectronicObserver.Window {
 
 			APIObserver o = APIObserver.Instance;
 
-			APIReceivedEventHandler rec = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( Updated ), apiname, data );
-			
-			o.APIList["api_req_kousyou/createship"].RequestReceived += rec;
-			o.APIList["api_req_kousyou/createship_speedchange"].RequestReceived += rec;
+			o.APIList["api_req_kousyou/createship"].RequestReceived += Updated;
+			o.APIList["api_req_kousyou/createship_speedchange"].RequestReceived += Updated;
 
-			o.APIList["api_get_member/kdock"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/getship"].ResponseReceived += rec;
+			o.APIList["api_get_member/kdock"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/getship"].ResponseReceived += Updated;
 
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;
 

--- a/ElectronicObserver/Window/FormBattle.cs
+++ b/ElectronicObserver/Window/FormBattle.cs
@@ -87,24 +87,22 @@ namespace ElectronicObserver.Window {
 
 			APIObserver o = APIObserver.Instance;
 
-			APIReceivedEventHandler rec = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( Updated ), apiname, data );
-
-			o.APIList["api_port/port"].ResponseReceived += rec;
-			o.APIList["api_req_map/start"].ResponseReceived += rec;
-			o.APIList["api_req_map/next"].ResponseReceived += rec;
-			o.APIList["api_req_sortie/battle"].ResponseReceived += rec;
-			o.APIList["api_req_sortie/battleresult"].ResponseReceived += rec;
-			o.APIList["api_req_battle_midnight/battle"].ResponseReceived += rec;
-			o.APIList["api_req_battle_midnight/sp_midnight"].ResponseReceived += rec;
-			o.APIList["api_req_combined_battle/battle"].ResponseReceived += rec;
-			o.APIList["api_req_combined_battle/midnight_battle"].ResponseReceived += rec;
-			o.APIList["api_req_combined_battle/sp_midnight"].ResponseReceived += rec;
-			o.APIList["api_req_combined_battle/airbattle"].ResponseReceived += rec;
-			o.APIList["api_req_combined_battle/battle_water"].ResponseReceived += rec;
-			o.APIList["api_req_combined_battle/battleresult"].ResponseReceived += rec;
-			o.APIList["api_req_practice/battle"].ResponseReceived += rec;
-			o.APIList["api_req_practice/midnight_battle"].ResponseReceived += rec;
-			o.APIList["api_req_practice/battle_result"].ResponseReceived += rec;
+			o.APIList["api_port/port"].ResponseReceived += Updated;
+			o.APIList["api_req_map/start"].ResponseReceived += Updated;
+			o.APIList["api_req_map/next"].ResponseReceived += Updated;
+			o.APIList["api_req_sortie/battle"].ResponseReceived += Updated;
+			o.APIList["api_req_sortie/battleresult"].ResponseReceived += Updated;
+			o.APIList["api_req_battle_midnight/battle"].ResponseReceived += Updated;
+			o.APIList["api_req_battle_midnight/sp_midnight"].ResponseReceived += Updated;
+			o.APIList["api_req_combined_battle/battle"].ResponseReceived += Updated;
+			o.APIList["api_req_combined_battle/midnight_battle"].ResponseReceived += Updated;
+			o.APIList["api_req_combined_battle/sp_midnight"].ResponseReceived += Updated;
+			o.APIList["api_req_combined_battle/airbattle"].ResponseReceived += Updated;
+			o.APIList["api_req_combined_battle/battle_water"].ResponseReceived += Updated;
+			o.APIList["api_req_combined_battle/battleresult"].ResponseReceived += Updated;
+			o.APIList["api_req_practice/battle"].ResponseReceived += Updated;
+			o.APIList["api_req_practice/midnight_battle"].ResponseReceived += Updated;
+			o.APIList["api_req_practice/battle_result"].ResponseReceived += Updated;
 
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;
 

--- a/ElectronicObserver/Window/FormBrowserHost.cs
+++ b/ElectronicObserver/Window/FormBrowserHost.cs
@@ -159,7 +159,7 @@ namespace ElectronicObserver.Window {
 			SetParent( BrowserWnd, this.Handle );
 			MoveWindow( BrowserWnd, 0, 0, this.Width, this.Height, true );
 
-			// 後は非同期で処理
+			// デッドロックするので非同期で処理
 			BeginInvoke( (Action)( () => {
 				// ブラウザプロセスに接続
 				Browser.Connect( ServerUri + "Browser/Browser" );

--- a/ElectronicObserver/Window/FormBrowserHost.cs
+++ b/ElectronicObserver/Window/FormBrowserHost.cs
@@ -33,10 +33,23 @@ namespace ElectronicObserver.Window {
 
 		private IntPtr BrowserWnd = IntPtr.Zero;
 
+		// デバッグ用初期APIロードが完了した後に、艦これページを開くようにするため
+		// APIロードの完了で+1、ブラウザ起動の完了で+1、最終的に2になる
+		private int initializeCompletionCount = 0;
+
 		public FormBrowserHost( FormMain parent ) {
 			InitializeComponent();
 
 			Icon = ResourceManager.ImageToIcon( ResourceManager.Instance.Icons.Images[(int)ResourceManager.IconContent.FormBrowser] );
+		}
+
+		public void InitializeApiCompleted() {
+			++initializeCompletionCount;
+			if ( initializeCompletionCount == 2 ) { // ブラウザ起動も完了していたら実行
+				if ( Utility.Configuration.Config.FormBrowser.IsEnabled ) {
+					NavigateToLogInPage();
+				}
+			}
 		}
 
 		private void FormBrowser_Load( object sender, EventArgs e ) {
@@ -65,6 +78,7 @@ namespace ElectronicObserver.Window {
 
 		//ロード直後の適用ではレイアウトがなぜか崩れるのでこのタイミングでも適用
 		void InitialAPIReceived( string apiname, dynamic data ) {
+			if ( initializeCompletionCount < 2 ) return; // 未初期化状態なので、まだ
 			Browser.AsyncRemoteRun( () => Browser.Proxy.InitialAPIReceived() );
 		}
 
@@ -180,8 +194,12 @@ namespace ElectronicObserver.Window {
 						Browser.Proxy.SetProxy( Observer.APIObserver.Instance.ProxyPort ) );
 				};
 
-				if ( Utility.Configuration.Config.FormBrowser.IsEnabled )
-					NavigateToLogInPage();
+				++initializeCompletionCount;
+				if ( initializeCompletionCount == 2 ) { // APIロードも完了していたら実行
+					if ( Utility.Configuration.Config.FormBrowser.IsEnabled ) {
+						NavigateToLogInPage();
+					}
+				}
 			} ) );
 		}
 

--- a/ElectronicObserver/Window/FormCompass.cs
+++ b/ElectronicObserver/Window/FormCompass.cs
@@ -308,22 +308,18 @@ namespace ElectronicObserver.Window {
 
 			APIObserver o = APIObserver.Instance;
 
-			APIReceivedEventHandler rec = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( Updated ), apiname, data );
+			o.APIList["api_port/port"].ResponseReceived += Updated;
+			o.APIList["api_req_map/start"].ResponseReceived += Updated;
+			o.APIList["api_req_map/next"].ResponseReceived += Updated;
+			o.APIList["api_req_member/get_practice_enemyinfo"].ResponseReceived += Updated;
 
-			o.APIList["api_port/port"].ResponseReceived += rec;
-			o.APIList["api_req_map/start"].ResponseReceived += rec;
-			o.APIList["api_req_map/next"].ResponseReceived += rec;
-			o.APIList["api_req_member/get_practice_enemyinfo"].ResponseReceived += rec;
-
-			APIReceivedEventHandler rec2 = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( BattleStarted ), apiname, data );
-
-			o.APIList["api_req_sortie/battle"].ResponseReceived += rec2;
-			o.APIList["api_req_battle_midnight/sp_midnight"].ResponseReceived += rec2;
-			o.APIList["api_req_combined_battle/battle"].ResponseReceived += rec2;
-			o.APIList["api_req_combined_battle/sp_midnight"].ResponseReceived += rec2;
-			o.APIList["api_req_combined_battle/airbattle"].ResponseReceived += rec2;
-			o.APIList["api_req_combined_battle/battle_water"].ResponseReceived += rec2;
-			o.APIList["api_req_practice/battle"].ResponseReceived += rec2;
+			o.APIList["api_req_sortie/battle"].ResponseReceived += BattleStarted;
+			o.APIList["api_req_battle_midnight/sp_midnight"].ResponseReceived += BattleStarted;
+			o.APIList["api_req_combined_battle/battle"].ResponseReceived += BattleStarted;
+			o.APIList["api_req_combined_battle/sp_midnight"].ResponseReceived += BattleStarted;
+			o.APIList["api_req_combined_battle/airbattle"].ResponseReceived += BattleStarted;
+			o.APIList["api_req_combined_battle/battle_water"].ResponseReceived += BattleStarted;
+			o.APIList["api_req_practice/battle"].ResponseReceived += BattleStarted;
 
 
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;

--- a/ElectronicObserver/Window/FormDock.cs
+++ b/ElectronicObserver/Window/FormDock.cs
@@ -163,13 +163,11 @@ namespace ElectronicObserver.Window {
 
 			APIObserver o = APIObserver.Instance;
 
-			APIReceivedEventHandler rec = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( Updated ), apiname, data );
+			o.APIList["api_req_nyukyo/start"].RequestReceived += Updated;
+			o.APIList["api_req_nyukyo/speedchange"].RequestReceived += Updated;
 
-			o.APIList["api_req_nyukyo/start"].RequestReceived += rec;
-			o.APIList["api_req_nyukyo/speedchange"].RequestReceived += rec;
-
-			o.APIList["api_port/port"].ResponseReceived += rec;
-			o.APIList["api_get_member/ndock"].ResponseReceived += rec;
+			o.APIList["api_port/port"].ResponseReceived += Updated;
+			o.APIList["api_get_member/ndock"].ResponseReceived += Updated;
 
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;
 		}

--- a/ElectronicObserver/Window/FormFleet.cs
+++ b/ElectronicObserver/Window/FormFleet.cs
@@ -531,34 +531,31 @@ namespace ElectronicObserver.Window {
 
 			APIObserver o = APIObserver.Instance;
 
-			APIReceivedEventHandler rec = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( Updated ), apiname, data );
-			APIReceivedEventHandler r_org = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( ChangeOrganization ), apiname, data );
+			o.APIList["api_req_hensei/change"].RequestReceived += ChangeOrganization;
+			o.APIList["api_req_kousyou/destroyship"].RequestReceived += ChangeOrganization;
+			o.APIList["api_req_kaisou/remodeling"].RequestReceived += ChangeOrganization;
+			o.APIList["api_req_kaisou/powerup"].ResponseReceived += ChangeOrganization;
 
-			o.APIList["api_req_hensei/change"].RequestReceived += r_org;
-			o.APIList["api_req_kousyou/destroyship"].RequestReceived += r_org;
-			o.APIList["api_req_kaisou/remodeling"].RequestReceived += r_org;
-			o.APIList["api_req_kaisou/powerup"].ResponseReceived += r_org;
-		
-			o.APIList["api_req_nyukyo/start"].RequestReceived += rec;
-			o.APIList["api_req_nyukyo/speedchange"].RequestReceived += rec;
-			o.APIList["api_req_hensei/change"].RequestReceived += rec;
-			o.APIList["api_req_kousyou/destroyship"].RequestReceived += rec;
-			o.APIList["api_req_member/updatedeckname"].RequestReceived += rec;
-			o.APIList["api_req_kaisou/remodeling"].RequestReceived += rec;
-			o.APIList["api_req_map/start"].RequestReceived += rec;
+			o.APIList["api_req_nyukyo/start"].RequestReceived += Updated;
+			o.APIList["api_req_nyukyo/speedchange"].RequestReceived += Updated;
+			o.APIList["api_req_hensei/change"].RequestReceived += Updated;
+			o.APIList["api_req_kousyou/destroyship"].RequestReceived += Updated;
+			o.APIList["api_req_member/updatedeckname"].RequestReceived += Updated;
+			o.APIList["api_req_kaisou/remodeling"].RequestReceived += Updated;
+			o.APIList["api_req_map/start"].RequestReceived += Updated;
 
-			o.APIList["api_port/port"].ResponseReceived += rec;
-			o.APIList["api_get_member/ship2"].ResponseReceived += rec;
-			o.APIList["api_get_member/ndock"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/getship"].ResponseReceived += rec;
-			o.APIList["api_req_hokyu/charge"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/destroyship"].ResponseReceived += rec;
-			o.APIList["api_get_member/ship3"].ResponseReceived += rec;
-			o.APIList["api_req_kaisou/powerup"].ResponseReceived += rec;		//requestのほうは面倒なのでこちらでまとめてやる
-			o.APIList["api_get_member/deck"].ResponseReceived += rec;
-			o.APIList["api_get_member/slot_item"].ResponseReceived += rec;
-			o.APIList["api_req_map/start"].ResponseReceived += rec;
-			o.APIList["api_req_map/next"].ResponseReceived += rec;
+			o.APIList["api_port/port"].ResponseReceived += Updated;
+			o.APIList["api_get_member/ship2"].ResponseReceived += Updated;
+			o.APIList["api_get_member/ndock"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/getship"].ResponseReceived += Updated;
+			o.APIList["api_req_hokyu/charge"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/destroyship"].ResponseReceived += Updated;
+			o.APIList["api_get_member/ship3"].ResponseReceived += Updated;
+			o.APIList["api_req_kaisou/powerup"].ResponseReceived += Updated;		//requestのほうは面倒なのでこちらでまとめてやる
+			o.APIList["api_get_member/deck"].ResponseReceived += Updated;
+			o.APIList["api_get_member/slot_item"].ResponseReceived += Updated;
+			o.APIList["api_req_map/start"].ResponseReceived += Updated;
+			o.APIList["api_req_map/next"].ResponseReceived += Updated;
 			
 
 			//追加するときは FormFleetOverview にも同様に追加してください

--- a/ElectronicObserver/Window/FormFleetOverview.cs
+++ b/ElectronicObserver/Window/FormFleetOverview.cs
@@ -159,32 +159,29 @@ namespace ElectronicObserver.Window {
 			//api register
 			APIObserver o = APIObserver.Instance;
 
-			APIReceivedEventHandler rec = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( Updated ), apiname, data );
-			APIReceivedEventHandler r_org = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( ChangeOrganization ), apiname, data );
+			o.APIList["api_req_hensei/change"].RequestReceived += ChangeOrganization;
+			o.APIList["api_req_kousyou/destroyship"].RequestReceived += ChangeOrganization;
+			o.APIList["api_req_kaisou/remodeling"].RequestReceived += ChangeOrganization;
+			o.APIList["api_req_kaisou/powerup"].ResponseReceived += ChangeOrganization;
 
-			o.APIList["api_req_hensei/change"].RequestReceived += r_org;
-			o.APIList["api_req_kousyou/destroyship"].RequestReceived += r_org;
-			o.APIList["api_req_kaisou/remodeling"].RequestReceived += r_org;
-			o.APIList["api_req_kaisou/powerup"].ResponseReceived += r_org;
-		
-			o.APIList["api_req_nyukyo/start"].RequestReceived += rec;
-			o.APIList["api_req_nyukyo/speedchange"].RequestReceived += rec;
-			o.APIList["api_req_hensei/change"].RequestReceived += rec;
-			o.APIList["api_req_kousyou/destroyship"].RequestReceived += rec;
-			o.APIList["api_req_member/updatedeckname"].RequestReceived += rec;
-			o.APIList["api_req_map/start"].RequestReceived += rec;
+			o.APIList["api_req_nyukyo/start"].RequestReceived += Updated;
+			o.APIList["api_req_nyukyo/speedchange"].RequestReceived += Updated;
+			o.APIList["api_req_hensei/change"].RequestReceived += Updated;
+			o.APIList["api_req_kousyou/destroyship"].RequestReceived += Updated;
+			o.APIList["api_req_member/updatedeckname"].RequestReceived += Updated;
+			o.APIList["api_req_map/start"].RequestReceived += Updated;
 
-			o.APIList["api_port/port"].ResponseReceived += rec;
-			o.APIList["api_get_member/ship2"].ResponseReceived += rec;
-			o.APIList["api_get_member/ndock"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/getship"].ResponseReceived += rec;
-			o.APIList["api_req_hokyu/charge"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/destroyship"].ResponseReceived += rec;
-			o.APIList["api_get_member/ship3"].ResponseReceived += rec;
-			o.APIList["api_req_kaisou/powerup"].ResponseReceived += rec;		//requestのほうは面倒なのでこちらでまとめてやる
-			o.APIList["api_get_member/deck"].ResponseReceived += rec;
-			o.APIList["api_req_map/start"].ResponseReceived += rec;
-			o.APIList["api_req_map/next"].ResponseReceived += rec;
+			o.APIList["api_port/port"].ResponseReceived += Updated;
+			o.APIList["api_get_member/ship2"].ResponseReceived += Updated;
+			o.APIList["api_get_member/ndock"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/getship"].ResponseReceived += Updated;
+			o.APIList["api_req_hokyu/charge"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/destroyship"].ResponseReceived += Updated;
+			o.APIList["api_get_member/ship3"].ResponseReceived += Updated;
+			o.APIList["api_req_kaisou/powerup"].ResponseReceived += Updated;		//requestのほうは面倒なのでこちらでまとめてやる
+			o.APIList["api_get_member/deck"].ResponseReceived += Updated;
+			o.APIList["api_req_map/start"].ResponseReceived += Updated;
+			o.APIList["api_req_map/next"].ResponseReceived += Updated;
 			
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;
 		}

--- a/ElectronicObserver/Window/FormHeadquarters.cs
+++ b/ElectronicObserver/Window/FormHeadquarters.cs
@@ -67,27 +67,25 @@ namespace ElectronicObserver.Window {
 
 			APIObserver o = APIObserver.Instance;
 
-			APIReceivedEventHandler rec = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( Updated ), apiname, data );
+			o.APIList["api_req_nyukyo/start"].RequestReceived += Updated;
+			o.APIList["api_req_nyukyo/speedchange"].RequestReceived += Updated;
+			o.APIList["api_req_kousyou/createship"].RequestReceived += Updated;
+			o.APIList["api_req_kousyou/createship_speedchange"].RequestReceived += Updated;
+			o.APIList["api_req_kousyou/destroyship"].RequestReceived += Updated;
+			o.APIList["api_req_kousyou/destroyitem2"].RequestReceived += Updated;
 
-			o.APIList["api_req_nyukyo/start"].RequestReceived += rec;
-			o.APIList["api_req_nyukyo/speedchange"].RequestReceived += rec;
-			o.APIList["api_req_kousyou/createship"].RequestReceived += rec;
-			o.APIList["api_req_kousyou/createship_speedchange"].RequestReceived += rec;
-			o.APIList["api_req_kousyou/destroyship"].RequestReceived += rec;
-			o.APIList["api_req_kousyou/destroyitem2"].RequestReceived += rec;
-
-			o.APIList["api_get_member/basic"].ResponseReceived += rec;
-			o.APIList["api_get_member/slot_item"].ResponseReceived += rec;
-			o.APIList["api_port/port"].ResponseReceived += rec;
-			o.APIList["api_get_member/ship2"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/getship"].ResponseReceived += rec;
-			o.APIList["api_req_hokyu/charge"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/destroyship"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/destroyitem2"].ResponseReceived += rec;
-			o.APIList["api_req_kaisou/powerup"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/createitem"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/remodel_slot"].ResponseReceived += rec;
-			o.APIList["api_get_member/material"].ResponseReceived += rec;
+			o.APIList["api_get_member/basic"].ResponseReceived += Updated;
+			o.APIList["api_get_member/slot_item"].ResponseReceived += Updated;
+			o.APIList["api_port/port"].ResponseReceived += Updated;
+			o.APIList["api_get_member/ship2"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/getship"].ResponseReceived += Updated;
+			o.APIList["api_req_hokyu/charge"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/destroyship"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/destroyitem2"].ResponseReceived += Updated;
+			o.APIList["api_req_kaisou/powerup"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/createitem"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/remodel_slot"].ResponseReceived += Updated;
+			o.APIList["api_get_member/material"].ResponseReceived += Updated;
 
 
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;

--- a/ElectronicObserver/Window/FormInformation.cs
+++ b/ElectronicObserver/Window/FormInformation.cs
@@ -34,15 +34,13 @@ namespace ElectronicObserver.Window {
 
 			APIObserver o = APIObserver.Instance;
 
-			APIReceivedEventHandler rec = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( Updated ), apiname, data );
-
-			o.APIList["api_port/port"].ResponseReceived += rec;
-			o.APIList["api_req_member/get_practice_enemyinfo"].ResponseReceived += rec;
-			o.APIList["api_get_member/picture_book"].ResponseReceived += rec;
-			o.APIList["api_req_kousyou/createitem"].ResponseReceived += rec;
-			o.APIList["api_get_member/mapinfo"].ResponseReceived += rec;
-			o.APIList["api_req_mission/result"].ResponseReceived += rec;
-			o.APIList["api_req_ranking/getlist"].ResponseReceived += rec;
+			o.APIList["api_port/port"].ResponseReceived += Updated;
+			o.APIList["api_req_member/get_practice_enemyinfo"].ResponseReceived += Updated;
+			o.APIList["api_get_member/picture_book"].ResponseReceived += Updated;
+			o.APIList["api_req_kousyou/createitem"].ResponseReceived += Updated;
+			o.APIList["api_get_member/mapinfo"].ResponseReceived += Updated;
+			o.APIList["api_req_mission/result"].ResponseReceived += Updated;
+			o.APIList["api_req_ranking/getlist"].ResponseReceived += Updated;
 
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;
 		}

--- a/ElectronicObserver/Window/FormLog.cs
+++ b/ElectronicObserver/Window/FormLog.cs
@@ -29,7 +29,16 @@ namespace ElectronicObserver.Window {
 			}
 			LogList.TopIndex = LogList.Items.Count - 1;
 
-			Utility.Logger.Instance.LogAdded += new Utility.LogAddedEventHandler( ( Utility.Logger.LogData data ) => Invoke( new Utility.LogAddedEventHandler( Logger_LogAdded ), data ) );
+			Utility.Logger.Instance.LogAdded += new Utility.LogAddedEventHandler( ( Utility.Logger.LogData data ) => {
+				if ( InvokeRequired ) {
+					// Invokeはメッセージキューにジョブを投げて待つので、別のBeginInvokeされたジョブが既にキューにあると、
+					// それを実行してしまい、BeginInvokeされたジョブの順番が保てなくなる
+					// GUIスレッドによる処理は、順番が重要なことがあるので、GUIスレッドからInvokeを呼び出してはいけない
+					Invoke( new Utility.LogAddedEventHandler( Logger_LogAdded ), data );
+				} else {
+					Logger_LogAdded( data );
+				}
+			} );
 
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;
 

--- a/ElectronicObserver/Window/FormMain.cs
+++ b/ElectronicObserver/Window/FormMain.cs
@@ -74,7 +74,7 @@ namespace ElectronicObserver.Window {
 
 			Icon = ResourceManager.Instance.AppIcon;
 
-			APIObserver.Instance.Start( Utility.Configuration.Config.Connection.Port );
+			APIObserver.Instance.Start( Utility.Configuration.Config.Connection.Port, this );
 
 
 			MainDockPanel.Extender.FloatWindowFactory = new CustomFloatWindowFactory();

--- a/ElectronicObserver/Window/FormMain.cs
+++ b/ElectronicObserver/Window/FormMain.cs
@@ -58,7 +58,16 @@ namespace ElectronicObserver.Window {
 			Utility.Configuration.Instance.Load();
 
 
-			Utility.Logger.Instance.LogAdded += new Utility.LogAddedEventHandler( ( Utility.Logger.LogData data ) => Invoke( new Utility.LogAddedEventHandler( Logger_LogAdded ), data ) );
+			Utility.Logger.Instance.LogAdded += new Utility.LogAddedEventHandler( ( Utility.Logger.LogData data ) => {
+				if ( InvokeRequired ) {
+					// Invokeはメッセージキューにジョブを投げて待つので、別のBeginInvokeされたジョブが既にキューにあると、
+					// それを実行してしまい、BeginInvokeされたジョブの順番が保てなくなる
+					// GUIスレッドによる処理は、順番が重要なことがあるので、GUIスレッドからInvokeを呼び出してはいけない
+					Invoke( new Utility.LogAddedEventHandler( Logger_LogAdded ), data );
+				} else {
+					Logger_LogAdded( data );
+				}
+			} );
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;
 
 			Utility.Logger.Add( 2, SoftwareInformation.SoftwareNameJapanese + " を起動しています…" );

--- a/ElectronicObserver/Window/FormMain.cs
+++ b/ElectronicObserver/Window/FormMain.cs
@@ -107,12 +107,6 @@ namespace ElectronicObserver.Window {
 
 			SoftwareInformation.CheckUpdate();
 
-
-			UIUpdateTimer.Start();
-
-			Utility.Logger.Add( 2, "起動処理が完了しました。" );
-
-
 			// デバッグ: 開始時にAPIリストを読み込む
 			if ( Configuration.Config.Debug.LoadAPIListOnLoad ) {
 
@@ -126,6 +120,12 @@ namespace ElectronicObserver.Window {
 				}
 			}
 
+			// 完了通知（ログインページを開く）
+			fBrowser.InitializeApiCompleted();
+
+			UIUpdateTimer.Start();
+
+			Utility.Logger.Add( 2, "起動処理が完了しました。" );
 		}
 
 
@@ -520,10 +520,15 @@ namespace ElectronicObserver.Window {
 							Array.Sort( files );
 
 							using ( StreamReader sr2 = new StreamReader( files[files.Length - 1] ) ) {
-								if ( isRequest )
-									APIObserver.Instance.LoadRequest( "/kcsapi/" + line, sr2.ReadToEnd() );
-								else
-									APIObserver.Instance.LoadResponse( "/kcsapi/" + line, sr2.ReadToEnd() );
+								if ( isRequest ) {
+									Invoke( (Action)( () => {
+										APIObserver.Instance.LoadRequest( "/kcsapi/" + line, sr2.ReadToEnd() );
+									} ) );
+								} else {
+									Invoke( (Action)( () => {
+										APIObserver.Instance.LoadResponse( "/kcsapi/" + line, sr2.ReadToEnd() );
+									} ) );
+								}
 							}
 
 							//System.Diagnostics.Debug.WriteLine( "APIList Loader: API " + line + " File " + files[files.Length-1] + " Loaded." );

--- a/ElectronicObserver/Window/FormQuest.cs
+++ b/ElectronicObserver/Window/FormQuest.cs
@@ -62,7 +62,7 @@ namespace ElectronicObserver.Window {
 			o.APIList["api_get_member/questlist"].ResponseReceived += rec;
 			//*/
 
-			KCDatabase.Instance.Quest.QuestUpdated += () => Invoke( new Action( Updated ) );
+			KCDatabase.Instance.Quest.QuestUpdated += Updated;
 
 
 			ClearQuestView();

--- a/ElectronicObserver/Window/FormShipGroup.cs
+++ b/ElectronicObserver/Window/FormShipGroup.cs
@@ -152,10 +152,8 @@ namespace ElectronicObserver.Window {
 			
 			APIObserver o = APIObserver.Instance;
 
-			APIReceivedEventHandler rec = ( string apiname, dynamic data ) => Invoke( new APIReceivedEventHandler( APIUpdated ), apiname, data );
-
-			o.APIList["api_port/port"].ResponseReceived += rec;
-			o.APIList["api_get_member/ship2"].ResponseReceived += rec;
+			o.APIList["api_port/port"].ResponseReceived += APIUpdated;
+			o.APIList["api_get_member/ship2"].ResponseReceived += APIUpdated;
 
 
 			Utility.Configuration.Instance.ConfigurationChanged += ConfigurationChanged;


### PR DESCRIPTION
通信とGUI更新を非同期に行うことで通信レスポンスを改善しました。

通信スレッドはAPIObserverのFiddlerイベントハンドラ２つに押し込めて、他は基本全てGUIスレッドで処理しています。Fiddlerイベントハンドラのファイル書き込み部分は別スレッド化しました。Loggerのスレッド間の競合が起こりそうな部分にロックの追加と、必要なくなったInvoke呼び出しの廃止も行っています。

お使い頂ければ幸いです。