### PR TITLE
ウィンドウレイアウトの保存に失敗することがあったので修正

### DIFF
--- a/ElectronicObserver/Window/FormMain.cs
+++ b/ElectronicObserver/Window/FormMain.cs
@@ -374,12 +374,15 @@ namespace ElectronicObserver.Window {
 
 			try {
 
-				using ( var stream = File.OpenWrite( path ) ) {
+				using ( var stream = File.Open( path, FileMode.Create ) ) {
 					using ( var archive = new ZipArchive( stream, ZipArchiveMode.Create ) ) {
 
-						SaveSubWindowsLayout( archive.CreateEntry( "SubWindowLayout.xml" ).Open() );
-						WindowPlacementManager.SaveWindowPlacement( this, archive.CreateEntry( "WindowPlacement.xml" ).Open() );
-
+						using ( var layoutstream = archive.CreateEntry( "SubWindowLayout.xml" ).Open() ) {
+							SaveSubWindowsLayout( layoutstream );
+						}
+						using ( var placementstream = archive.CreateEntry( "WindowPlacement.xml" ).Open() ) {
+							WindowPlacementManager.SaveWindowPlacement( this, placementstream );
+						}
 					}
 				}
 


### PR DESCRIPTION
ちょっと使い方が悪かったのかもしれませんが、以下の様なエラーが出ていたので修正しました。あと、OpenWriteは長いファイルに短いファイルを上書きすると、新旧のデータが混在するそうなので、そこも修正しました。お使い頂ければ幸いです。

エラーレポート : 2015/03/13 21:50:05
エラー : IOException
以前に作成されたエントリが開いているときはエントリを作成できません。
追加情報 : ウィンドウ レイアウトの保存に失敗しました。
スタックトレース：
   場所 System.IO.Compression.ZipArchive.AcquireArchiveStream(ZipArchiveEntry entry)
   場所 System.IO.Compression.ZipArchiveEntry..ctor(ZipArchive archive, String entryName)
   場所 System.IO.Compression.ZipArchive.DoCreateEntry(String entryName, Nullable`1 compressionLevel)
   場所 System.IO.Compression.ZipArchive.CreateEntry(String entryName)
   場所 ElectronicObserver.Window.FormMain.SaveLayout(String path) 場所 x:\Switch\Visual Studio 2012\Projects\ElectronicObserver\ElectronicObserver\Window\FormMain.cs:行 384
