### PR TITLE
艦隊ウィンドウをスリム化

### DIFF
--- a/ElectronicObserver/Window/Control/ShipStatusEquipment.cs
+++ b/ElectronicObserver/Window/Control/ShipStatusEquipment.cs
@@ -198,8 +198,9 @@ namespace ElectronicObserver.Window.Control {
 		/// <param name="ship">当該艦船。</param>
 		public void SetSlotList( ShipData ship ) {
 
-			if ( SlotList.Length != ship.Slot.Count ) {
-				SlotList = new SlotItem[ship.Slot.Count];
+			int SlotCount = Math.Min( 4, ship.Slot.Count ); // 味方艦は装備4つまでなので4つに制限
+			if ( SlotList.Length != SlotCount ) {
+				SlotList = new SlotItem[SlotCount];
 				for ( int i = 0; i < SlotList.Length; i++ ) {
 					SlotList[i] = new SlotItem();
 				}
@@ -293,7 +294,7 @@ namespace ElectronicObserver.Window.Control {
 			}
 
 			Size sz_eststr = TextRenderer.MeasureText( "99", Font, new Size( int.MaxValue, int.MaxValue ), textformat );
-			sz_eststr.Width -= (int)( Font.Size / 2.0 );
+			sz_eststr.Width -= (int)( Font.Size / 1.5 );
 			
 			Size sz_unit = new Size( eqimages.ImageSize.Width + SlotMargin, eqimages.ImageSize.Height );
 			if ( ShowAircraft ) {
@@ -387,15 +388,31 @@ namespace ElectronicObserver.Window.Control {
 
 				if ( drawAircraftSlot ) {
 					Rectangle textarea = new Rectangle( basearea.X + sz_unit.Width * slotindex, basearea.Y, sz_unit.Width - SlotMargin, sz_unit.Height );
+					String aircraftSlotText = slot.AircraftCurrent.ToString();
 
 					if ( OverlayAircraft ) {
 						using ( SolidBrush b = new SolidBrush( Color.FromArgb( 0x80, 0xFF, 0xFF, 0xFF ) ) ) {
 							e.Graphics.FillRectangle( b, new Rectangle( textarea.X, textarea.Y, sz_eststr.Width, sz_eststr.Height ) );
 						}
+					} else {
+						if ( aircraftSlotText.Length == 1 ) {
+							// 1文字の場合は画像に近づける
+							textarea.Width -= sz_eststr.Width / 2;
+						}
+						if ( aircraftSlotText.Length > 2 ) { // 3文字以上の時はかぶるので背景を薄くする
+							Size sz_realstr = TextRenderer.MeasureText( aircraftSlotText, Font, new Size( int.MaxValue, int.MaxValue ), textformat );
+							sz_realstr.Width -= (int)( Font.Size / 2.0 );
+							using ( SolidBrush b = new SolidBrush( Color.FromArgb( 0xC0, 0xFF, 0xFF, 0xFF ) ) ) {
+								e.Graphics.FillRectangle( b, new Rectangle(
+									textarea.X + sz_unit.Width - sz_realstr.Width,
+									textarea.Y + sz_unit.Height - sz_realstr.Height,
+									sz_realstr.Width, sz_realstr.Height ) );
+							}
+						}
 					}
-					
 
-					TextRenderer.DrawText( e.Graphics, slot.AircraftCurrent.ToString(), Font, textarea, aircraftColor, textformat );
+
+					TextRenderer.DrawText( e.Graphics, aircraftSlotText, Font, textarea, aircraftColor, textformat );
 				}
 
 			}
@@ -418,7 +435,7 @@ namespace ElectronicObserver.Window.Control {
 			}
 
 			Size sz_eststr = TextRenderer.MeasureText( "99", Font, new Size( int.MaxValue, int.MaxValue ), textformat );
-			sz_eststr.Width -= (int)( Font.Size / 2.0 );
+			sz_eststr.Width -= (int)( Font.Size / 1.5 );
 
 			Size sz_unit = new Size( eqimages.ImageSize.Width + SlotMargin, eqimages.ImageSize.Height );
 			if ( ShowAircraft ) {

--- a/ElectronicObserver/Window/Control/ShipStatusHP.cs
+++ b/ElectronicObserver/Window/Control/ShipStatusHP.cs
@@ -282,15 +282,14 @@ namespace ElectronicObserver.Window.Control {
 
 				Size sz_text = TextRenderer.MeasureText( Text, SubFont, maxsize, TextFormatText );
 				Size sz_hpmax = TextRenderer.MeasureText( Math.Max( MaximumValue, MaximumDigit ).ToString(), SubFont, maxsize, TextFormatHP );
-				Size sz_slash = TextRenderer.MeasureText( " / ", SubFont, maxsize, TextFormatHP );
+				Size sz_slash = TextRenderer.MeasureText( "/", SubFont, maxsize, TextFormatHP );
 				Size sz_hpnow = TextRenderer.MeasureText( Math.Max( Value, MaximumDigit ).ToString(), MainFont, maxsize, TextFormatHP );
 
 				if ( Text.Length > 0 )
-					sz_text.Width -= (int)( SubFont.Size / 2.0 );
-				sz_hpmax.Width -= (int)( SubFont.Size / 2.0 );
-				sz_slash.Width -= (int)( SubFont.Size / 2.0 );
-				sz_hpnow.Width -= (int)( MainFont.Size / 2.0 );
-
+					sz_text.Width -= (int)( SubFont.Size / 1.5 );
+				sz_hpmax.Width -= (int)( SubFont.Size / 1.5 );
+				sz_slash.Width -= (int)( SubFont.Size / 1.5 );
+				sz_hpnow.Width -= (int)( MainFont.Size / 1.5 );
 
 
 				Point p = new Point( basearea.X, basearea.Bottom - barSize.Height - sz_text.Height + 1 );	
@@ -302,7 +301,7 @@ namespace ElectronicObserver.Window.Control {
 				//g.DrawRectangle( Pens.Orange, new Rectangle( p, sz_hpmax ) );
 
 				p.X -= sz_slash.Width;
-				TextRenderer.DrawText( g, " / ", SubFont, new Rectangle( p, sz_slash ), SubFontColor, TextFormatHP );
+				TextRenderer.DrawText( g, "/", SubFont, new Rectangle( p, sz_slash ), SubFontColor, TextFormatHP );
 				//g.DrawRectangle( Pens.Orange, new Rectangle( p, sz_slash ) );
 
 				p.X -= sz_hpnow.Width;
@@ -325,14 +324,14 @@ namespace ElectronicObserver.Window.Control {
 
 			Size sz_text = TextRenderer.MeasureText( Text, SubFont, maxsize, TextFormatText );
 			Size sz_hpmax = TextRenderer.MeasureText( Math.Max( MaximumValue, MaximumDigit ).ToString(), SubFont, maxsize, TextFormatHP );
-			Size sz_slash = TextRenderer.MeasureText( " / ", SubFont, maxsize, TextFormatHP );
+			Size sz_slash = TextRenderer.MeasureText( "/", SubFont, maxsize, TextFormatHP );
 			Size sz_hpnow = TextRenderer.MeasureText( Math.Max( Value, MaximumDigit ).ToString(), MainFont, maxsize, TextFormatHP );
 
 			if ( Text.Length > 0 )
-				sz_text.Width -= (int)( SubFont.Size / 2.0 );
-			sz_hpmax.Width -= (int)( SubFont.Size / 2.0 );
-			sz_slash.Width -= (int)( SubFont.Size / 2.0 );
-			sz_hpnow.Width -= (int)( MainFont.Size / 2.0 );
+				sz_text.Width -= (int)( SubFont.Size / 1.5 );
+			sz_hpmax.Width -= (int)( SubFont.Size / 1.5 );
+			sz_slash.Width -= (int)( SubFont.Size / 1.5 );
+			sz_hpnow.Width -= (int)( MainFont.Size / 1.5 );
 
 			return new Size( sz_text.Width + sz_hpnow.Width + sz_slash.Width + sz_hpmax.Width + Padding.Horizontal,
 				Math.Max( sz_text.Height, sz_hpnow.Height ) + barSize.Height + Padding.Vertical );

--- a/ElectronicObserver/Window/FormFleet.Designer.cs
+++ b/ElectronicObserver/Window/FormFleet.Designer.cs
@@ -35,20 +35,21 @@
 			// 
 			// TableMember
 			// 
-			this.TableMember.AutoSize = true;
 			this.TableMember.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
 			this.TableMember.ColumnCount = 6;
-			this.TableMember.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.TableMember.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
 			this.TableMember.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.TableMember.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.TableMember.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.TableMember.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.TableMember.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.TableMember.Location = new System.Drawing.Point(0, 24);
+			this.TableMember.MaximumSize = new System.Drawing.Size(500, 0);
+			this.TableMember.MinimumSize = new System.Drawing.Size(360, 0);
 			this.TableMember.Name = "TableMember";
 			this.TableMember.RowCount = 1;
 			this.TableMember.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 21F));
-			this.TableMember.Size = new System.Drawing.Size(0, 21);
+			this.TableMember.Size = new System.Drawing.Size(390, 21);
 			this.TableMember.TabIndex = 1;
 			this.TableMember.CellPaint += new System.Windows.Forms.TableLayoutCellPaintEventHandler(this.TableMember_CellPaint);
 			// 
@@ -75,20 +76,20 @@
             this.ContextMenuFleet_CopyFleet,
             this.ContextMenuFleet_Capture});
 			this.ContextMenuFleet.Name = "ContextMenuFleet";
-			this.ContextMenuFleet.Size = new System.Drawing.Size(227, 48);
+			this.ContextMenuFleet.Size = new System.Drawing.Size(188, 48);
 			this.ContextMenuFleet.Opening += new System.ComponentModel.CancelEventHandler(this.ContextMenuFleet_Opening);
 			// 
 			// ContextMenuFleet_CopyFleet
 			// 
 			this.ContextMenuFleet_CopyFleet.Name = "ContextMenuFleet_CopyFleet";
-			this.ContextMenuFleet_CopyFleet.Size = new System.Drawing.Size(226, 22);
+			this.ContextMenuFleet_CopyFleet.Size = new System.Drawing.Size(187, 22);
 			this.ContextMenuFleet_CopyFleet.Text = "クリップボードにコピー(&C)";
 			this.ContextMenuFleet_CopyFleet.Click += new System.EventHandler(this.ContextMenuFleet_CopyFleet_Click);
 			// 
 			// ContextMenuFleet_Capture
 			// 
 			this.ContextMenuFleet_Capture.Name = "ContextMenuFleet_Capture";
-			this.ContextMenuFleet_Capture.Size = new System.Drawing.Size(226, 22);
+			this.ContextMenuFleet_Capture.Size = new System.Drawing.Size(187, 22);
 			this.ContextMenuFleet_Capture.Text = "この画面をキャプチャ(&S)";
 			this.ContextMenuFleet_Capture.Click += new System.EventHandler(this.ContextMenuFleet_Capture_Click);
 			// 
@@ -103,11 +104,10 @@
 			// 
 			this.AutoHidePortion = 150D;
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-			this.AutoScroll = true;
 			this.BackColor = System.Drawing.SystemColors.Control;
-			this.ClientSize = new System.Drawing.Size(300, 200);
-			this.Controls.Add(this.TableFleet);
+			this.ClientSize = new System.Drawing.Size(390, 200);
 			this.Controls.Add(this.TableMember);
+			this.Controls.Add(this.TableFleet);
 			this.DoubleBuffered = true;
 			this.Font = new System.Drawing.Font("Meiryo UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
 			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
@@ -116,6 +116,7 @@
 			this.Name = "FormFleet";
 			this.Text = "*not loaded*";
 			this.Load += new System.EventHandler(this.FormFleet_Load);
+			this.Resize += new System.EventHandler(this.FormFleet_Resize);
 			this.ContextMenuFleet.ResumeLayout(false);
 			this.ResumeLayout(false);
 			this.PerformLayout();

--- a/ElectronicObserver/Window/FormFleet.cs
+++ b/ElectronicObserver/Window/FormFleet.cs
@@ -177,7 +177,7 @@ namespace ElectronicObserver.Window {
 
 
 		private class TableMemberControl {
-			public Label Name;
+			public TextBox Name;
 			public ShipStatusLevel Level;
 			public ShipStatusHP HP;
 			public ImageLabel Condition;
@@ -192,7 +192,7 @@ namespace ElectronicObserver.Window {
 
 				#region Initialize
 
-				Name = new Label();
+				Name = new TextBox();
 				Name.SuspendLayout();
 				Name.Text = "*nothing*";
 				Name.Anchor = AnchorStyles.Left;
@@ -204,6 +204,10 @@ namespace ElectronicObserver.Window {
 				Name.Visible = false;
 				Name.Cursor = Cursors.Help;
 				Name.MouseDown += Name_MouseDown;
+				Name.ReadOnly = true;
+				Name.TabStop = false;
+				Name.BorderStyle = BorderStyle.None;
+				Name.ContextMenu = new ContextMenu();
 				Name.ResumeLayout();
 
 				Level = new ShipStatusLevel();
@@ -248,9 +252,10 @@ namespace ElectronicObserver.Window {
 				Condition.ForeColor = parent.MainFontColor;
 				Condition.TextAlign = ContentAlignment.BottomRight;
 				Condition.ImageAlign = ContentAlignment.MiddleLeft;
+				Condition.ImageMargin = 0;
 				Condition.ImageList = ResourceManager.Instance.Icons;
-				Condition.Padding = new Padding( 2, 2, 2, 2 );
-				Condition.Margin = new Padding( 2, 0, 2, 0 );
+				Condition.Padding = new Padding( 0, 2, 0, 2 );
+				Condition.Margin = new Padding( 0, 0, 0, 0 );
 				Condition.Size = new Size( 40, 20 );
 				Condition.AutoSize = true;
 				Condition.Visible = false;
@@ -265,7 +270,7 @@ namespace ElectronicObserver.Window {
 				ShipResource.Anchor = AnchorStyles.Left;
 				ShipResource.Padding = new Padding( 0, 2, 0, 1 );
 				ShipResource.Margin = new Padding( 2, 0, 2, 0 );
-				ShipResource.Size = new Size( 40, 20 );
+				ShipResource.Size = new Size( 30, 20 );
 				ShipResource.AutoSize = false;
 				ShipResource.Visible = false;
 				ShipResource.ResumeLayout();
@@ -280,6 +285,7 @@ namespace ElectronicObserver.Window {
 				Equipments.AutoSize = true;
 				Equipments.Visible = false;
 				Equipments.ShowAircraft = Utility.Configuration.Config.FormFleet.ShowAircraft;
+				Equipments.SlotMargin = 0;
 				Equipments.ResumeLayout();
 
 
@@ -602,6 +608,7 @@ namespace ElectronicObserver.Window {
 			for ( int i = 0; i < ControlMember.Length; i++ ) {
 				ControlMember[i].Update( fleet.Members[i] );
 			}
+			TableMember.Height = TableMember.GetPreferredSize( Size.Empty ).Height;
 			TableMember.ResumeLayout();
 
 
@@ -732,6 +739,10 @@ namespace ElectronicObserver.Window {
 
 		protected override string GetPersistString() {
 			return "Fleet #" + FleetID.ToString();
+		}
+
+		private void FormFleet_Resize( object sender, EventArgs e ) {
+			TableMember.Width = Width;
 		}
 
 


### PR DESCRIPTION
艦隊ウィンドウの幅をスリム化しました。変更点は以下の通りです。

- 艦名部分の長さを中身に関係なくウィンドウの幅から計算するようにして、テーブルの長さとウィンドウの長さをなるべく一致するようにしました
- 艦名はLabelだと意図した動作が難しかったためTextBoxに変更しました。
- 装備表示を最大4つにしました
- 装備間のマージンをゼロ、艦載機数表示を1桁の時は画像に近づけるようにしました
- HP表示の文字幅を調整して短くしました
- 燃料・弾薬ゲージを40px→30pxに短くしました
- スクロールバーは消しました

スクロールバーや艦名表示幅固定などの設定追加とコンフリクトしてしまっているところは申し訳ありません。また、GUIデザインに関わる部分なので、気に入らないようでしたら採用していただかなくても構いません。検討して頂ければ幸いです。よろしくお願いいたします。