### PR TITLE
マシンのタイムゾーン設定によって残り時間が正しく表示されない問題を修正

### DIFF
--- a/ElectronicObserver/Utility/Mathematics/DateTimeHelper.cs
+++ b/ElectronicObserver/Utility/Mathematics/DateTimeHelper.cs
@@ -14,7 +14,7 @@ namespace ElectronicObserver.Utility.Mathematics {
 		/// <summary>
 		/// 起点となる日時。
 		/// </summary>
-		private static readonly DateTime origin = new DateTime( 1970, 1, 1, 9, 0, 0 );
+		private static readonly long origin = new DateTime( 1970, 1, 1, 0, 0, 0 ).Ticks;
 
 
 		/// <summary>
@@ -23,7 +23,7 @@ namespace ElectronicObserver.Utility.Mathematics {
 		/// <param name="time">日時データ。</param>
 		/// <returns>変換された<see cref="DateTime"/>。</returns>
 		public static DateTime FromAPITime( long time ) {
-			return new DateTime( time * 10000 + origin.Ticks );
+			return new DateTime( time * 10000 + origin, DateTimeKind.Utc ).ToLocalTime();
 		}
 
 		/// <summary>
@@ -32,7 +32,7 @@ namespace ElectronicObserver.Utility.Mathematics {
 		/// <param name="time">日時データ。</param>
 		/// <returns>変換された日時のAPIデータ。</returns>
 		public static long ToAPITime( DateTime time ) {
-			return ( time.Ticks - origin.Ticks ) / 10000;
+			return ( time.ToUniversalTime().Ticks - origin ) / 10000;
 		}
 
 


### PR DESCRIPTION
小さな修正です。

参考) UNIX時間からDateTimeへの変換
http://smdn.jp/programming/netfx/tips/convert_unixtime_into_datetime/