### PR TITLE
2-5新秋簡易式対応

### DIFF
--- a/ElectronicObserver/Data/FleetData.cs
+++ b/ElectronicObserver/Data/FleetData.cs
@@ -404,6 +404,9 @@ namespace ElectronicObserver.Data {
 
 				case 1:
 					return Calculator.GetSearchingAbility_Autumn( this );
+
+				case 2:
+					return Calculator.GetSearchingAbility_TinyAutumn( this );
 			}
 		}
 
@@ -411,13 +414,25 @@ namespace ElectronicObserver.Data {
 		/// 現在の設定に応じて、索敵能力を表す文字列を取得します。
 		/// </summary>
 		public string GetSearchingAbilityString() {
-			switch ( Utility.Configuration.Config.FormFleet.SearchingAbilityMethod ) {
+			return this.GetSearchingAbilityString( Utility.Configuration.Config.FormFleet.SearchingAbilityMethod );
+		}
+
+		/// <summary>
+		/// 指定の計算式で、索敵能力を表す文字列を取得します。
+		/// </summary>
+		/// <param name="index">計算式。0-2</param>
+		public string GetSearchingAbilityString( int index ) {
+			switch ( index )
+			{
 				default:
 				case 0:
 					return Calculator.GetSearchingAbility_Old( this ).ToString();
 
 				case 1:
 					return Calculator.GetSearchingAbility_Autumn( this ).ToString( "F1" );
+
+				case 2:
+					return Calculator.GetSearchingAbility_TinyAutumn( this ).ToString();
 			}
 		}
 

--- a/ElectronicObserver/Utility/Data/Calculator.cs
+++ b/ElectronicObserver/Utility/Data/Calculator.cs
@@ -236,6 +236,64 @@ namespace ElectronicObserver.Utility.Data {
 		}
 
 
+		/// <summary>
+		/// 索敵能力を求めます。「2-5式(秋)簡易式」です。
+		/// </summary>
+		/// <param name="fleet">対象の艦隊。</param>
+		public static double GetSearchingAbility_TinyAutumn(FleetData fleet)
+		{
+
+			double ret = 0.0;
+
+			foreach (var ship in fleet.MembersWithoutEscaped)
+			{
+				if (ship == null) continue;
+
+				double cur = Math.Sqrt(ship.LOSBase);
+
+				foreach (var eq in ship.SlotInstanceMaster)
+				{
+					if (eq == null) continue;
+
+					switch (eq.CategoryType)
+					{
+
+						case 7:		//艦爆
+							cur += eq.LOS * 0.6; break;
+
+						case 8:		//艦攻
+							cur += eq.LOS * 0.8; break;
+
+						case 9:		//艦偵
+							cur += eq.LOS * 1.0; break;
+
+						case 10:	//水偵
+							cur += eq.LOS * 1.2; break;
+
+						case 11:	//水爆
+							cur += eq.LOS * 1.0; break;
+
+						case 12:	//小型電探
+							cur += eq.LOS * 0.6; break;
+
+						case 13:	//大型電探
+							cur += eq.LOS * 0.6; break;
+
+						case 29:	//探照灯
+							cur += eq.LOS * 0.5; break;
+
+					}
+				}
+
+				ret += Math.Floor( cur );
+			}
+
+			ret -= Math.Floor( KCDatabase.Instance.Admiral.Level * 0.4 );
+
+			return Math.Round(ret, 1);
+		}
+
+
 
 
 		/// <summary>

--- a/ElectronicObserver/Window/Dialog/DialogConfiguration.Designer.cs
+++ b/ElectronicObserver/Window/Dialog/DialogConfiguration.Designer.cs
@@ -840,7 +840,8 @@
 			this.FormFleet_SearchingAbilityMethod.FormattingEnabled = true;
 			this.FormFleet_SearchingAbilityMethod.Items.AddRange(new object[] {
             "(旧)2-5式",
-            "2-5式(秋)"});
+            "2-5式(秋)",
+            "2-5新秋簡易式"});
 			this.FormFleet_SearchingAbilityMethod.Location = new System.Drawing.Point(115, 31);
 			this.FormFleet_SearchingAbilityMethod.Name = "FormFleet_SearchingAbilityMethod";
 			this.FormFleet_SearchingAbilityMethod.Size = new System.Drawing.Size(121, 23);

--- a/ElectronicObserver/Window/FormFleet.cs
+++ b/ElectronicObserver/Window/FormFleet.cs
@@ -158,6 +158,11 @@ namespace ElectronicObserver.Window {
 
 				//索敵能力計算
 				SearchingAbility.Text = fleet.GetSearchingAbilityString();
+				ToolTipInfo.SetToolTip( SearchingAbility,
+					string.Format( "(旧)2-5式: {0}\r\n2-5式(秋): {1}\r\n2-5新秋簡易式: {2}\r\n",
+					fleet.GetSearchingAbilityString( 0 ),
+					fleet.GetSearchingAbilityString( 1 ),
+					fleet.GetSearchingAbilityString( 2 ) ) );
 
 			}
 


### PR DESCRIPTION
2-5新秋簡易式に対応してみました。
詳細は http://nekokan333.blog.fc2.com/blog-entry-345.html にありますが、
要するに、ほっぽアルファさんで採用されている索敵値計算式です。
ついでに、ツールチップで各索敵値を並べて確認できるようにしてあります。
もしよければ取り込んでくださいませ。