### PR TITLE
Flash抽出に失敗することがあるのを修正

### DIFF
--- a/Browser/Browser.csproj
+++ b/Browser/Browser.csproj
@@ -72,6 +72,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Dpi.cs" />
     <Compile Include="FormBrowser.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -80,6 +81,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ScreenHelper.cs" />
     <Compile Include="VolumeManager.cs" />
     <EmbeddedResource Include="FormBrowser.resx">
       <DependentUpon>FormBrowser.cs</DependentUpon>

--- a/Browser/Dpi.cs
+++ b/Browser/Dpi.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Browser
+{
+    class Dpi
+    {
+        public static readonly Dpi Default = new Dpi(96, 96);
+
+        public uint X { get; private set; }
+        public uint Y { get; private set; }
+
+        public Dpi(uint x, uint y)
+        {
+            this.X = x;
+            this.Y = y;
+        }
+
+        public double ScaleX
+        {
+            get { return this.X / (double)Default.X; }
+        }
+
+        public double ScaleY
+        {
+            get { return this.Y / (double)Default.Y; }
+        }
+    }
+}

--- a/Browser/FormBrowser.cs
+++ b/Browser/FormBrowser.cs
@@ -293,13 +293,20 @@ namespace Browser {
 				var wb = Browser.ActiveXInstance as SHDocVw.IWebBrowser2;
 				if ( wb == null || wb.ReadyState == SHDocVw.tagREADYSTATE.READYSTATE_UNINITIALIZED || wb.Busy ) return;
 
-				object pin = zoomRate;
+				var dpi = ScreenHelper.GetSystemDpi();
+                var zoomFactor = dpi.ScaleX + (zoomRate / 100.0 - 1.0);
+                var percentage = (int)(zoomFactor * 100);
+
+                object pin = percentage;
 				object pout = null;
 
 				wb.ExecWB( SHDocVw.OLECMDID.OLECMDID_OPTICAL_ZOOM, SHDocVw.OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, ref pin, ref pout );
 
 				if ( StyleSheetApplied ) {
-					Browser.Size = Browser.MinimumSize = new Size( (int)( KanColleSize.Width * zoomRate / 100.0 ), (int)( KanColleSize.Height * zoomRate / 100.0 ) );
+                    Browser.Size = Browser.MinimumSize = new Size(
+                        (int)(KanColleSize.Width * (zoomFactor / dpi.ScaleX)),
+                        (int)(KanColleSize.Height * (zoomFactor / dpi.ScaleY))
+                        );
 					CenteringBrowser();
 				}
 

--- a/Browser/ScreenHelper.cs
+++ b/Browser/ScreenHelper.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Browser
+{
+    static class ScreenHelper
+    {
+        [DllImport("user32.dll")]
+        static extern IntPtr GetDC(IntPtr ptr);
+        [DllImport("user32.dll")]
+        static extern IntPtr ReleaseDC(IntPtr hWnd, IntPtr hDc);
+        [DllImport("gdi32.dll")]
+        static extern uint GetDeviceCaps(
+        IntPtr hdc, // handle to DC
+        int nIndex // index of capability
+        );
+        [DllImport("user32.dll")]
+        static extern bool SetProcessDPIAware();
+
+        const int LOGPIXELSX = 88;
+        const int LOGPIXELSY = 90;
+
+        static Dpi _dpi;
+        public static Dpi GetSystemDpi()
+        {
+            if (_dpi == null)
+            {
+                SetProcessDPIAware(); //重要
+                IntPtr screenDC = GetDC(IntPtr.Zero);
+                uint dpi_x = GetDeviceCaps(screenDC, LOGPIXELSX);
+                uint dpi_y = GetDeviceCaps(screenDC, LOGPIXELSY);
+                _dpi = new Dpi(dpi_x, dpi_y);
+                ReleaseDC(IntPtr.Zero, screenDC);
+            }
+            return _dpi;
+        }
+    }
+}


### PR DESCRIPTION
拾い物ですが、DPIが100%でない時への対応です。

Flash抽出失敗は私のところだと以下の環境で再現しました
- Windows 8.1

画面解像度→テキストやその他の項目の大きさの変更 で
- 中 - 125%
- すべてのディスプレイで同じ拡大率を使用するをチェック