### PR TITLE
艦船グループ:編成中の艦隊を追加する機能の追加

### DIFF
--- a/ElectronicObserver/Window/FormShipGroup.Designer.cs
+++ b/ElectronicObserver/Window/FormShipGroup.Designer.cs
@@ -23,91 +23,92 @@
 		/// the contents of this method with the code editor.
 		/// </summary>
 		private void InitializeComponent() {
-			this.components = new System.ComponentModel.Container();
-			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle16 = new System.Windows.Forms.DataGridViewCellStyle();
-			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
-			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
-			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
-			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
-			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle13 = new System.Windows.Forms.DataGridViewCellStyle();
-			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle14 = new System.Windows.Forms.DataGridViewCellStyle();
-			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle15 = new System.Windows.Forms.DataGridViewCellStyle();
-			this.ShipView = new System.Windows.Forms.DataGridView();
-			this.ShipView_ID = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_ShipType = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Name = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Level = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Exp = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Next = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_NextRemodel = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_HP = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Condition = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Fuel = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Ammo = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Equipment1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Equipment2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Equipment3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Equipment4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Equipment5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Fleet = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_RepairTime = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Firepower = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_FirepowerRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Torpedo = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_TorpedoRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_AA = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_AARemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Armor = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_ArmorRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_ASW = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Evasion = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_LOS = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Luck = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_LuckRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_Locked = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.ShipView_SallyArea = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.MenuMember = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.MenuMember_AddToGroup = new System.Windows.Forms.ToolStripMenuItem();
-			this.MenuMember_CreateGroup = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.MenuMember_ColumnFilter = new System.Windows.Forms.ToolStripMenuItem();
-			this.MenuMember_ColumnAutoSize = new System.Windows.Forms.ToolStripMenuItem();
-			this.MenuMember_LockShipNameScroll = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.MenuMember_CSVOutput = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.MenuMember_Delete = new System.Windows.Forms.ToolStripMenuItem();
-			this.MenuGroup = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.MenuGroup_Add = new System.Windows.Forms.ToolStripMenuItem();
-			this.MenuGroup_Rename = new System.Windows.Forms.ToolStripMenuItem();
-			this.MenuGroup_Delete = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.MenuGroup_AutoUpdate = new System.Windows.Forms.ToolStripMenuItem();
-			this.MenuGroup_ShowStatusBar = new System.Windows.Forms.ToolStripMenuItem();
-			this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-			this.TabPanel = new System.Windows.Forms.FlowLayoutPanel();
-			this.StatusBar = new System.Windows.Forms.StatusStrip();
-			this.Status_ShipCount = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Status_LevelTotal = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Status_LevelAverage = new System.Windows.Forms.ToolStripStatusLabel();
-			((System.ComponentModel.ISupportInitialize)(this.ShipView)).BeginInit();
-			this.MenuMember.SuspendLayout();
-			this.MenuGroup.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-			this.splitContainer1.Panel1.SuspendLayout();
-			this.splitContainer1.Panel2.SuspendLayout();
-			this.splitContainer1.SuspendLayout();
-			this.StatusBar.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// ShipView
-			// 
-			this.ShipView.AllowUserToAddRows = false;
-			this.ShipView.AllowUserToDeleteRows = false;
-			this.ShipView.AllowUserToResizeRows = false;
-			this.ShipView.BackgroundColor = System.Drawing.SystemColors.Control;
-			this.ShipView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-			this.ShipView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.components = new System.ComponentModel.Container();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.ShipView = new System.Windows.Forms.DataGridView();
+            this.ShipView_ID = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_ShipType = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Name = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Level = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Exp = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Next = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_NextRemodel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_HP = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Condition = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Fuel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Ammo = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Equipment1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Equipment2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Equipment3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Equipment4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Equipment5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Fleet = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_RepairTime = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Firepower = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_FirepowerRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Torpedo = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_TorpedoRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_AA = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_AARemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Armor = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_ArmorRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_ASW = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Evasion = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_LOS = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Luck = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_LuckRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_Locked = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShipView_SallyArea = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.MenuMember = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.MenuMember_AddToGroup = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuMember_CreateGroup = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.MenuMember_ColumnFilter = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuMember_ColumnAutoSize = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuMember_LockShipNameScroll = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.MenuMember_CSVOutput = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.MenuMember_Delete = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuGroup = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.MenuGroup_Add = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuGroup_Rename = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuGroup_Delete = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+            this.MenuGroup_AutoUpdate = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuGroup_ShowStatusBar = new System.Windows.Forms.ToolStripMenuItem();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.TabPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.StatusBar = new System.Windows.Forms.StatusStrip();
+            this.Status_ShipCount = new System.Windows.Forms.ToolStripStatusLabel();
+            this.Status_LevelTotal = new System.Windows.Forms.ToolStripStatusLabel();
+            this.Status_LevelAverage = new System.Windows.Forms.ToolStripStatusLabel();
+            this.MenuMember_AddCurrentFleet_Group = new System.Windows.Forms.ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)(this.ShipView)).BeginInit();
+            this.MenuMember.SuspendLayout();
+            this.MenuGroup.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.StatusBar.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // ShipView
+            // 
+            this.ShipView.AllowUserToAddRows = false;
+            this.ShipView.AllowUserToDeleteRows = false;
+            this.ShipView.AllowUserToResizeRows = false;
+            this.ShipView.BackgroundColor = System.Drawing.SystemColors.Control;
+            this.ShipView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
+            this.ShipView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.ShipView_ID,
             this.ShipView_ShipType,
             this.ShipView_Name,
@@ -141,283 +142,284 @@
             this.ShipView_LuckRemain,
             this.ShipView_Locked,
             this.ShipView_SallyArea});
-			this.ShipView.ContextMenuStrip = this.MenuMember;
-			dataGridViewCellStyle16.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
-			dataGridViewCellStyle16.BackColor = System.Drawing.SystemColors.Window;
-			dataGridViewCellStyle16.Font = new System.Drawing.Font("Meiryo UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
-			dataGridViewCellStyle16.ForeColor = System.Drawing.SystemColors.ControlText;
-			dataGridViewCellStyle16.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-			dataGridViewCellStyle16.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-			dataGridViewCellStyle16.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-			this.ShipView.DefaultCellStyle = dataGridViewCellStyle16;
-			this.ShipView.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.ShipView.Location = new System.Drawing.Point(0, 0);
-			this.ShipView.Name = "ShipView";
-			this.ShipView.ReadOnly = true;
-			this.ShipView.RowHeadersVisible = false;
-			this.ShipView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-			this.ShipView.Size = new System.Drawing.Size(300, 134);
-			this.ShipView.TabIndex = 0;
-			this.ShipView.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.ShipView_CellFormatting);
-			this.ShipView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.ShipView_SortCompare);
-			this.ShipView.Sorted += new System.EventHandler(this.ShipView_Sorted);
-			// 
-			// ShipView_ID
-			// 
-			this.ShipView_ID.Frozen = true;
-			this.ShipView_ID.HeaderText = "ID";
-			this.ShipView_ID.Name = "ShipView_ID";
-			this.ShipView_ID.ReadOnly = true;
-			this.ShipView_ID.Width = 50;
-			// 
-			// ShipView_ShipType
-			// 
-			dataGridViewCellStyle9.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-			this.ShipView_ShipType.DefaultCellStyle = dataGridViewCellStyle9;
-			this.ShipView_ShipType.Frozen = true;
-			this.ShipView_ShipType.HeaderText = "艦種";
-			this.ShipView_ShipType.Name = "ShipView_ShipType";
-			this.ShipView_ShipType.ReadOnly = true;
-			this.ShipView_ShipType.Width = 80;
-			// 
-			// ShipView_Name
-			// 
-			dataGridViewCellStyle10.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-			this.ShipView_Name.DefaultCellStyle = dataGridViewCellStyle10;
-			this.ShipView_Name.Frozen = true;
-			this.ShipView_Name.HeaderText = "艦名";
-			this.ShipView_Name.Name = "ShipView_Name";
-			this.ShipView_Name.ReadOnly = true;
-			// 
-			// ShipView_Level
-			// 
-			this.ShipView_Level.HeaderText = "Lv";
-			this.ShipView_Level.Name = "ShipView_Level";
-			this.ShipView_Level.ReadOnly = true;
-			this.ShipView_Level.Width = 40;
-			// 
-			// ShipView_Exp
-			// 
-			this.ShipView_Exp.HeaderText = "Exp";
-			this.ShipView_Exp.Name = "ShipView_Exp";
-			this.ShipView_Exp.ReadOnly = true;
-			this.ShipView_Exp.Width = 60;
-			// 
-			// ShipView_Next
-			// 
-			this.ShipView_Next.HeaderText = "next";
-			this.ShipView_Next.Name = "ShipView_Next";
-			this.ShipView_Next.ReadOnly = true;
-			this.ShipView_Next.Width = 60;
-			// 
-			// ShipView_NextRemodel
-			// 
-			this.ShipView_NextRemodel.HeaderText = "改装まで";
-			this.ShipView_NextRemodel.Name = "ShipView_NextRemodel";
-			this.ShipView_NextRemodel.ReadOnly = true;
-			this.ShipView_NextRemodel.Width = 60;
-			// 
-			// ShipView_HP
-			// 
-			this.ShipView_HP.HeaderText = "HP";
-			this.ShipView_HP.Name = "ShipView_HP";
-			this.ShipView_HP.ReadOnly = true;
-			this.ShipView_HP.Width = 60;
-			// 
-			// ShipView_Condition
-			// 
-			this.ShipView_Condition.HeaderText = "Cond";
-			this.ShipView_Condition.Name = "ShipView_Condition";
-			this.ShipView_Condition.ReadOnly = true;
-			this.ShipView_Condition.Width = 40;
-			// 
-			// ShipView_Fuel
-			// 
-			this.ShipView_Fuel.HeaderText = "燃料";
-			this.ShipView_Fuel.Name = "ShipView_Fuel";
-			this.ShipView_Fuel.ReadOnly = true;
-			this.ShipView_Fuel.Width = 60;
-			// 
-			// ShipView_Ammo
-			// 
-			this.ShipView_Ammo.HeaderText = "弾薬";
-			this.ShipView_Ammo.Name = "ShipView_Ammo";
-			this.ShipView_Ammo.ReadOnly = true;
-			this.ShipView_Ammo.Width = 60;
-			// 
-			// ShipView_Equipment1
-			// 
-			dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-			this.ShipView_Equipment1.DefaultCellStyle = dataGridViewCellStyle11;
-			this.ShipView_Equipment1.HeaderText = "装備1";
-			this.ShipView_Equipment1.Name = "ShipView_Equipment1";
-			this.ShipView_Equipment1.ReadOnly = true;
-			this.ShipView_Equipment1.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-			this.ShipView_Equipment1.Width = 150;
-			// 
-			// ShipView_Equipment2
-			// 
-			dataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-			this.ShipView_Equipment2.DefaultCellStyle = dataGridViewCellStyle12;
-			this.ShipView_Equipment2.HeaderText = "装備2";
-			this.ShipView_Equipment2.Name = "ShipView_Equipment2";
-			this.ShipView_Equipment2.ReadOnly = true;
-			this.ShipView_Equipment2.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-			this.ShipView_Equipment2.Width = 150;
-			// 
-			// ShipView_Equipment3
-			// 
-			dataGridViewCellStyle13.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-			this.ShipView_Equipment3.DefaultCellStyle = dataGridViewCellStyle13;
-			this.ShipView_Equipment3.HeaderText = "装備3";
-			this.ShipView_Equipment3.Name = "ShipView_Equipment3";
-			this.ShipView_Equipment3.ReadOnly = true;
-			this.ShipView_Equipment3.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-			this.ShipView_Equipment3.Width = 150;
-			// 
-			// ShipView_Equipment4
-			// 
-			dataGridViewCellStyle14.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-			this.ShipView_Equipment4.DefaultCellStyle = dataGridViewCellStyle14;
-			this.ShipView_Equipment4.HeaderText = "装備4";
-			this.ShipView_Equipment4.Name = "ShipView_Equipment4";
-			this.ShipView_Equipment4.ReadOnly = true;
-			this.ShipView_Equipment4.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-			this.ShipView_Equipment4.Width = 150;
-			// 
-			// ShipView_Equipment5
-			// 
-			dataGridViewCellStyle15.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-			this.ShipView_Equipment5.DefaultCellStyle = dataGridViewCellStyle15;
-			this.ShipView_Equipment5.HeaderText = "装備5";
-			this.ShipView_Equipment5.Name = "ShipView_Equipment5";
-			this.ShipView_Equipment5.ReadOnly = true;
-			this.ShipView_Equipment5.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-			this.ShipView_Equipment5.Width = 150;
-			// 
-			// ShipView_Fleet
-			// 
-			this.ShipView_Fleet.HeaderText = "艦隊";
-			this.ShipView_Fleet.Name = "ShipView_Fleet";
-			this.ShipView_Fleet.ReadOnly = true;
-			this.ShipView_Fleet.Width = 40;
-			// 
-			// ShipView_RepairTime
-			// 
-			this.ShipView_RepairTime.HeaderText = "入渠";
-			this.ShipView_RepairTime.Name = "ShipView_RepairTime";
-			this.ShipView_RepairTime.ReadOnly = true;
-			this.ShipView_RepairTime.Width = 60;
-			// 
-			// ShipView_Firepower
-			// 
-			this.ShipView_Firepower.HeaderText = "火力";
-			this.ShipView_Firepower.Name = "ShipView_Firepower";
-			this.ShipView_Firepower.ReadOnly = true;
-			this.ShipView_Firepower.Width = 40;
-			// 
-			// ShipView_FirepowerRemain
-			// 
-			this.ShipView_FirepowerRemain.HeaderText = "火力改修";
-			this.ShipView_FirepowerRemain.Name = "ShipView_FirepowerRemain";
-			this.ShipView_FirepowerRemain.ReadOnly = true;
-			this.ShipView_FirepowerRemain.Width = 40;
-			// 
-			// ShipView_Torpedo
-			// 
-			this.ShipView_Torpedo.HeaderText = "雷装";
-			this.ShipView_Torpedo.Name = "ShipView_Torpedo";
-			this.ShipView_Torpedo.ReadOnly = true;
-			this.ShipView_Torpedo.Width = 40;
-			// 
-			// ShipView_TorpedoRemain
-			// 
-			this.ShipView_TorpedoRemain.HeaderText = "雷装改修";
-			this.ShipView_TorpedoRemain.Name = "ShipView_TorpedoRemain";
-			this.ShipView_TorpedoRemain.ReadOnly = true;
-			this.ShipView_TorpedoRemain.Width = 40;
-			// 
-			// ShipView_AA
-			// 
-			this.ShipView_AA.HeaderText = "対空";
-			this.ShipView_AA.Name = "ShipView_AA";
-			this.ShipView_AA.ReadOnly = true;
-			this.ShipView_AA.Width = 40;
-			// 
-			// ShipView_AARemain
-			// 
-			this.ShipView_AARemain.HeaderText = "対空改修";
-			this.ShipView_AARemain.Name = "ShipView_AARemain";
-			this.ShipView_AARemain.ReadOnly = true;
-			this.ShipView_AARemain.Width = 40;
-			// 
-			// ShipView_Armor
-			// 
-			this.ShipView_Armor.HeaderText = "装甲";
-			this.ShipView_Armor.Name = "ShipView_Armor";
-			this.ShipView_Armor.ReadOnly = true;
-			this.ShipView_Armor.Width = 40;
-			// 
-			// ShipView_ArmorRemain
-			// 
-			this.ShipView_ArmorRemain.HeaderText = "装甲改修";
-			this.ShipView_ArmorRemain.Name = "ShipView_ArmorRemain";
-			this.ShipView_ArmorRemain.ReadOnly = true;
-			this.ShipView_ArmorRemain.Width = 40;
-			// 
-			// ShipView_ASW
-			// 
-			this.ShipView_ASW.HeaderText = "対潜";
-			this.ShipView_ASW.Name = "ShipView_ASW";
-			this.ShipView_ASW.ReadOnly = true;
-			this.ShipView_ASW.Width = 40;
-			// 
-			// ShipView_Evasion
-			// 
-			this.ShipView_Evasion.HeaderText = "回避";
-			this.ShipView_Evasion.Name = "ShipView_Evasion";
-			this.ShipView_Evasion.ReadOnly = true;
-			this.ShipView_Evasion.Width = 40;
-			// 
-			// ShipView_LOS
-			// 
-			this.ShipView_LOS.HeaderText = "索敵";
-			this.ShipView_LOS.Name = "ShipView_LOS";
-			this.ShipView_LOS.ReadOnly = true;
-			this.ShipView_LOS.Width = 40;
-			// 
-			// ShipView_Luck
-			// 
-			this.ShipView_Luck.HeaderText = "運";
-			this.ShipView_Luck.Name = "ShipView_Luck";
-			this.ShipView_Luck.ReadOnly = true;
-			this.ShipView_Luck.Width = 40;
-			// 
-			// ShipView_LuckRemain
-			// 
-			this.ShipView_LuckRemain.HeaderText = "運改修";
-			this.ShipView_LuckRemain.Name = "ShipView_LuckRemain";
-			this.ShipView_LuckRemain.ReadOnly = true;
-			this.ShipView_LuckRemain.Width = 40;
-			// 
-			// ShipView_Locked
-			// 
-			this.ShipView_Locked.HeaderText = "ロック";
-			this.ShipView_Locked.Name = "ShipView_Locked";
-			this.ShipView_Locked.ReadOnly = true;
-			this.ShipView_Locked.Width = 40;
-			// 
-			// ShipView_SallyArea
-			// 
-			this.ShipView_SallyArea.HeaderText = "出撃先";
-			this.ShipView_SallyArea.Name = "ShipView_SallyArea";
-			this.ShipView_SallyArea.ReadOnly = true;
-			this.ShipView_SallyArea.Width = 40;
-			// 
-			// MenuMember
-			// 
-			this.MenuMember.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ShipView.ContextMenuStrip = this.MenuMember;
+            dataGridViewCellStyle8.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
+            dataGridViewCellStyle8.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle8.Font = new System.Drawing.Font("Meiryo UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
+            dataGridViewCellStyle8.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle8.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle8.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle8.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.ShipView.DefaultCellStyle = dataGridViewCellStyle8;
+            this.ShipView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ShipView.Location = new System.Drawing.Point(0, 0);
+            this.ShipView.Name = "ShipView";
+            this.ShipView.ReadOnly = true;
+            this.ShipView.RowHeadersVisible = false;
+            this.ShipView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.ShipView.Size = new System.Drawing.Size(300, 134);
+            this.ShipView.TabIndex = 0;
+            this.ShipView.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.ShipView_CellFormatting);
+            this.ShipView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.ShipView_SortCompare);
+            this.ShipView.Sorted += new System.EventHandler(this.ShipView_Sorted);
+            // 
+            // ShipView_ID
+            // 
+            this.ShipView_ID.Frozen = true;
+            this.ShipView_ID.HeaderText = "ID";
+            this.ShipView_ID.Name = "ShipView_ID";
+            this.ShipView_ID.ReadOnly = true;
+            this.ShipView_ID.Width = 50;
+            // 
+            // ShipView_ShipType
+            // 
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            this.ShipView_ShipType.DefaultCellStyle = dataGridViewCellStyle1;
+            this.ShipView_ShipType.Frozen = true;
+            this.ShipView_ShipType.HeaderText = "艦種";
+            this.ShipView_ShipType.Name = "ShipView_ShipType";
+            this.ShipView_ShipType.ReadOnly = true;
+            this.ShipView_ShipType.Width = 80;
+            // 
+            // ShipView_Name
+            // 
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            this.ShipView_Name.DefaultCellStyle = dataGridViewCellStyle2;
+            this.ShipView_Name.Frozen = true;
+            this.ShipView_Name.HeaderText = "艦名";
+            this.ShipView_Name.Name = "ShipView_Name";
+            this.ShipView_Name.ReadOnly = true;
+            // 
+            // ShipView_Level
+            // 
+            this.ShipView_Level.HeaderText = "Lv";
+            this.ShipView_Level.Name = "ShipView_Level";
+            this.ShipView_Level.ReadOnly = true;
+            this.ShipView_Level.Width = 40;
+            // 
+            // ShipView_Exp
+            // 
+            this.ShipView_Exp.HeaderText = "Exp";
+            this.ShipView_Exp.Name = "ShipView_Exp";
+            this.ShipView_Exp.ReadOnly = true;
+            this.ShipView_Exp.Width = 60;
+            // 
+            // ShipView_Next
+            // 
+            this.ShipView_Next.HeaderText = "next";
+            this.ShipView_Next.Name = "ShipView_Next";
+            this.ShipView_Next.ReadOnly = true;
+            this.ShipView_Next.Width = 60;
+            // 
+            // ShipView_NextRemodel
+            // 
+            this.ShipView_NextRemodel.HeaderText = "改装まで";
+            this.ShipView_NextRemodel.Name = "ShipView_NextRemodel";
+            this.ShipView_NextRemodel.ReadOnly = true;
+            this.ShipView_NextRemodel.Width = 60;
+            // 
+            // ShipView_HP
+            // 
+            this.ShipView_HP.HeaderText = "HP";
+            this.ShipView_HP.Name = "ShipView_HP";
+            this.ShipView_HP.ReadOnly = true;
+            this.ShipView_HP.Width = 60;
+            // 
+            // ShipView_Condition
+            // 
+            this.ShipView_Condition.HeaderText = "Cond";
+            this.ShipView_Condition.Name = "ShipView_Condition";
+            this.ShipView_Condition.ReadOnly = true;
+            this.ShipView_Condition.Width = 40;
+            // 
+            // ShipView_Fuel
+            // 
+            this.ShipView_Fuel.HeaderText = "燃料";
+            this.ShipView_Fuel.Name = "ShipView_Fuel";
+            this.ShipView_Fuel.ReadOnly = true;
+            this.ShipView_Fuel.Width = 60;
+            // 
+            // ShipView_Ammo
+            // 
+            this.ShipView_Ammo.HeaderText = "弾薬";
+            this.ShipView_Ammo.Name = "ShipView_Ammo";
+            this.ShipView_Ammo.ReadOnly = true;
+            this.ShipView_Ammo.Width = 60;
+            // 
+            // ShipView_Equipment1
+            // 
+            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            this.ShipView_Equipment1.DefaultCellStyle = dataGridViewCellStyle3;
+            this.ShipView_Equipment1.HeaderText = "装備1";
+            this.ShipView_Equipment1.Name = "ShipView_Equipment1";
+            this.ShipView_Equipment1.ReadOnly = true;
+            this.ShipView_Equipment1.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.ShipView_Equipment1.Width = 150;
+            // 
+            // ShipView_Equipment2
+            // 
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            this.ShipView_Equipment2.DefaultCellStyle = dataGridViewCellStyle4;
+            this.ShipView_Equipment2.HeaderText = "装備2";
+            this.ShipView_Equipment2.Name = "ShipView_Equipment2";
+            this.ShipView_Equipment2.ReadOnly = true;
+            this.ShipView_Equipment2.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.ShipView_Equipment2.Width = 150;
+            // 
+            // ShipView_Equipment3
+            // 
+            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            this.ShipView_Equipment3.DefaultCellStyle = dataGridViewCellStyle5;
+            this.ShipView_Equipment3.HeaderText = "装備3";
+            this.ShipView_Equipment3.Name = "ShipView_Equipment3";
+            this.ShipView_Equipment3.ReadOnly = true;
+            this.ShipView_Equipment3.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.ShipView_Equipment3.Width = 150;
+            // 
+            // ShipView_Equipment4
+            // 
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            this.ShipView_Equipment4.DefaultCellStyle = dataGridViewCellStyle6;
+            this.ShipView_Equipment4.HeaderText = "装備4";
+            this.ShipView_Equipment4.Name = "ShipView_Equipment4";
+            this.ShipView_Equipment4.ReadOnly = true;
+            this.ShipView_Equipment4.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.ShipView_Equipment4.Width = 150;
+            // 
+            // ShipView_Equipment5
+            // 
+            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            this.ShipView_Equipment5.DefaultCellStyle = dataGridViewCellStyle7;
+            this.ShipView_Equipment5.HeaderText = "装備5";
+            this.ShipView_Equipment5.Name = "ShipView_Equipment5";
+            this.ShipView_Equipment5.ReadOnly = true;
+            this.ShipView_Equipment5.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.ShipView_Equipment5.Width = 150;
+            // 
+            // ShipView_Fleet
+            // 
+            this.ShipView_Fleet.HeaderText = "艦隊";
+            this.ShipView_Fleet.Name = "ShipView_Fleet";
+            this.ShipView_Fleet.ReadOnly = true;
+            this.ShipView_Fleet.Width = 40;
+            // 
+            // ShipView_RepairTime
+            // 
+            this.ShipView_RepairTime.HeaderText = "入渠";
+            this.ShipView_RepairTime.Name = "ShipView_RepairTime";
+            this.ShipView_RepairTime.ReadOnly = true;
+            this.ShipView_RepairTime.Width = 60;
+            // 
+            // ShipView_Firepower
+            // 
+            this.ShipView_Firepower.HeaderText = "火力";
+            this.ShipView_Firepower.Name = "ShipView_Firepower";
+            this.ShipView_Firepower.ReadOnly = true;
+            this.ShipView_Firepower.Width = 40;
+            // 
+            // ShipView_FirepowerRemain
+            // 
+            this.ShipView_FirepowerRemain.HeaderText = "火力改修";
+            this.ShipView_FirepowerRemain.Name = "ShipView_FirepowerRemain";
+            this.ShipView_FirepowerRemain.ReadOnly = true;
+            this.ShipView_FirepowerRemain.Width = 40;
+            // 
+            // ShipView_Torpedo
+            // 
+            this.ShipView_Torpedo.HeaderText = "雷装";
+            this.ShipView_Torpedo.Name = "ShipView_Torpedo";
+            this.ShipView_Torpedo.ReadOnly = true;
+            this.ShipView_Torpedo.Width = 40;
+            // 
+            // ShipView_TorpedoRemain
+            // 
+            this.ShipView_TorpedoRemain.HeaderText = "雷装改修";
+            this.ShipView_TorpedoRemain.Name = "ShipView_TorpedoRemain";
+            this.ShipView_TorpedoRemain.ReadOnly = true;
+            this.ShipView_TorpedoRemain.Width = 40;
+            // 
+            // ShipView_AA
+            // 
+            this.ShipView_AA.HeaderText = "対空";
+            this.ShipView_AA.Name = "ShipView_AA";
+            this.ShipView_AA.ReadOnly = true;
+            this.ShipView_AA.Width = 40;
+            // 
+            // ShipView_AARemain
+            // 
+            this.ShipView_AARemain.HeaderText = "対空改修";
+            this.ShipView_AARemain.Name = "ShipView_AARemain";
+            this.ShipView_AARemain.ReadOnly = true;
+            this.ShipView_AARemain.Width = 40;
+            // 
+            // ShipView_Armor
+            // 
+            this.ShipView_Armor.HeaderText = "装甲";
+            this.ShipView_Armor.Name = "ShipView_Armor";
+            this.ShipView_Armor.ReadOnly = true;
+            this.ShipView_Armor.Width = 40;
+            // 
+            // ShipView_ArmorRemain
+            // 
+            this.ShipView_ArmorRemain.HeaderText = "装甲改修";
+            this.ShipView_ArmorRemain.Name = "ShipView_ArmorRemain";
+            this.ShipView_ArmorRemain.ReadOnly = true;
+            this.ShipView_ArmorRemain.Width = 40;
+            // 
+            // ShipView_ASW
+            // 
+            this.ShipView_ASW.HeaderText = "対潜";
+            this.ShipView_ASW.Name = "ShipView_ASW";
+            this.ShipView_ASW.ReadOnly = true;
+            this.ShipView_ASW.Width = 40;
+            // 
+            // ShipView_Evasion
+            // 
+            this.ShipView_Evasion.HeaderText = "回避";
+            this.ShipView_Evasion.Name = "ShipView_Evasion";
+            this.ShipView_Evasion.ReadOnly = true;
+            this.ShipView_Evasion.Width = 40;
+            // 
+            // ShipView_LOS
+            // 
+            this.ShipView_LOS.HeaderText = "索敵";
+            this.ShipView_LOS.Name = "ShipView_LOS";
+            this.ShipView_LOS.ReadOnly = true;
+            this.ShipView_LOS.Width = 40;
+            // 
+            // ShipView_Luck
+            // 
+            this.ShipView_Luck.HeaderText = "運";
+            this.ShipView_Luck.Name = "ShipView_Luck";
+            this.ShipView_Luck.ReadOnly = true;
+            this.ShipView_Luck.Width = 40;
+            // 
+            // ShipView_LuckRemain
+            // 
+            this.ShipView_LuckRemain.HeaderText = "運改修";
+            this.ShipView_LuckRemain.Name = "ShipView_LuckRemain";
+            this.ShipView_LuckRemain.ReadOnly = true;
+            this.ShipView_LuckRemain.Width = 40;
+            // 
+            // ShipView_Locked
+            // 
+            this.ShipView_Locked.HeaderText = "ロック";
+            this.ShipView_Locked.Name = "ShipView_Locked";
+            this.ShipView_Locked.ReadOnly = true;
+            this.ShipView_Locked.Width = 40;
+            // 
+            // ShipView_SallyArea
+            // 
+            this.ShipView_SallyArea.HeaderText = "出撃先";
+            this.ShipView_SallyArea.Name = "ShipView_SallyArea";
+            this.ShipView_SallyArea.ReadOnly = true;
+            this.ShipView_SallyArea.Width = 40;
+            // 
+            // MenuMember
+            // 
+            this.MenuMember.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.MenuMember_AddToGroup,
+            this.MenuMember_AddCurrentFleet_Group,
             this.MenuMember_CreateGroup,
             this.toolStripSeparator1,
             this.MenuMember_ColumnFilter,
@@ -427,224 +429,230 @@
             this.MenuMember_CSVOutput,
             this.toolStripSeparator3,
             this.MenuMember_Delete});
-			this.MenuMember.Name = "MenuMember";
-			this.MenuMember.Size = new System.Drawing.Size(300, 176);
-			this.MenuMember.Opening += new System.ComponentModel.CancelEventHandler(this.MenuMember_Opening);
-			// 
-			// MenuMember_AddToGroup
-			// 
-			this.MenuMember_AddToGroup.Name = "MenuMember_AddToGroup";
-			this.MenuMember_AddToGroup.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D)));
-			this.MenuMember_AddToGroup.Size = new System.Drawing.Size(299, 22);
-			this.MenuMember_AddToGroup.Text = "グループへ追加(&A)...";
-			this.MenuMember_AddToGroup.Click += new System.EventHandler(this.MenuMember_AddToGroup_Click);
-			// 
-			// MenuMember_CreateGroup
-			// 
-			this.MenuMember_CreateGroup.Name = "MenuMember_CreateGroup";
-			this.MenuMember_CreateGroup.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            this.MenuMember.Name = "MenuMember";
+            this.MenuMember.Size = new System.Drawing.Size(300, 220);
+            this.MenuMember.Opening += new System.ComponentModel.CancelEventHandler(this.MenuMember_Opening);
+            // 
+            // MenuMember_AddToGroup
+            // 
+            this.MenuMember_AddToGroup.Name = "MenuMember_AddToGroup";
+            this.MenuMember_AddToGroup.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D)));
+            this.MenuMember_AddToGroup.Size = new System.Drawing.Size(299, 22);
+            this.MenuMember_AddToGroup.Text = "グループへ追加(&A)...";
+            this.MenuMember_AddToGroup.Click += new System.EventHandler(this.MenuMember_AddToGroup_Click);
+            // 
+            // MenuMember_CreateGroup
+            // 
+            this.MenuMember_CreateGroup.Name = "MenuMember_CreateGroup";
+            this.MenuMember_CreateGroup.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.D)));
-			this.MenuMember_CreateGroup.Size = new System.Drawing.Size(299, 22);
-			this.MenuMember_CreateGroup.Text = "新規グループを作成(&C)...";
-			this.MenuMember_CreateGroup.Click += new System.EventHandler(this.MenuMember_CreateGroup_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(296, 6);
-			// 
-			// MenuMember_ColumnFilter
-			// 
-			this.MenuMember_ColumnFilter.Name = "MenuMember_ColumnFilter";
-			this.MenuMember_ColumnFilter.Size = new System.Drawing.Size(299, 22);
-			this.MenuMember_ColumnFilter.Text = "列フィルタ(&F)...";
-			this.MenuMember_ColumnFilter.Click += new System.EventHandler(this.MenuMember_ColumnFilter_Click);
-			// 
-			// MenuMember_ColumnAutoSize
-			// 
-			this.MenuMember_ColumnAutoSize.CheckOnClick = true;
-			this.MenuMember_ColumnAutoSize.Name = "MenuMember_ColumnAutoSize";
-			this.MenuMember_ColumnAutoSize.Size = new System.Drawing.Size(299, 22);
-			this.MenuMember_ColumnAutoSize.Text = "列の自動調整(&D)";
-			this.MenuMember_ColumnAutoSize.Click += new System.EventHandler(this.MenuMember_ColumnAutoSize_Click);
-			// 
-			// MenuMember_LockShipNameScroll
-			// 
-			this.MenuMember_LockShipNameScroll.CheckOnClick = true;
-			this.MenuMember_LockShipNameScroll.Name = "MenuMember_LockShipNameScroll";
-			this.MenuMember_LockShipNameScroll.Size = new System.Drawing.Size(299, 22);
-			this.MenuMember_LockShipNameScroll.Text = "艦名をスクロールしない(&S)";
-			this.MenuMember_LockShipNameScroll.Click += new System.EventHandler(this.MenuMember_LockShipNameScroll_Click);
-			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(296, 6);
-			// 
-			// MenuMember_CSVOutput
-			// 
-			this.MenuMember_CSVOutput.Name = "MenuMember_CSVOutput";
-			this.MenuMember_CSVOutput.Size = new System.Drawing.Size(299, 22);
-			this.MenuMember_CSVOutput.Text = "CSV出力(&O)...";
-			this.MenuMember_CSVOutput.Click += new System.EventHandler(this.MenuMember_CSVOutput_Click);
-			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(296, 6);
-			// 
-			// MenuMember_Delete
-			// 
-			this.MenuMember_Delete.Name = "MenuMember_Delete";
-			this.MenuMember_Delete.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-			this.MenuMember_Delete.Size = new System.Drawing.Size(299, 22);
-			this.MenuMember_Delete.Text = "削除(&D)";
-			this.MenuMember_Delete.Click += new System.EventHandler(this.MenuMember_Delete_Click);
-			// 
-			// MenuGroup
-			// 
-			this.MenuGroup.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.MenuMember_CreateGroup.Size = new System.Drawing.Size(299, 22);
+            this.MenuMember_CreateGroup.Text = "新規グループを作成(&C)...";
+            this.MenuMember_CreateGroup.Click += new System.EventHandler(this.MenuMember_CreateGroup_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(296, 6);
+            // 
+            // MenuMember_ColumnFilter
+            // 
+            this.MenuMember_ColumnFilter.Name = "MenuMember_ColumnFilter";
+            this.MenuMember_ColumnFilter.Size = new System.Drawing.Size(299, 22);
+            this.MenuMember_ColumnFilter.Text = "列フィルタ(&F)...";
+            this.MenuMember_ColumnFilter.Click += new System.EventHandler(this.MenuMember_ColumnFilter_Click);
+            // 
+            // MenuMember_ColumnAutoSize
+            // 
+            this.MenuMember_ColumnAutoSize.CheckOnClick = true;
+            this.MenuMember_ColumnAutoSize.Name = "MenuMember_ColumnAutoSize";
+            this.MenuMember_ColumnAutoSize.Size = new System.Drawing.Size(299, 22);
+            this.MenuMember_ColumnAutoSize.Text = "列の自動調整(&D)";
+            this.MenuMember_ColumnAutoSize.Click += new System.EventHandler(this.MenuMember_ColumnAutoSize_Click);
+            // 
+            // MenuMember_LockShipNameScroll
+            // 
+            this.MenuMember_LockShipNameScroll.CheckOnClick = true;
+            this.MenuMember_LockShipNameScroll.Name = "MenuMember_LockShipNameScroll";
+            this.MenuMember_LockShipNameScroll.Size = new System.Drawing.Size(299, 22);
+            this.MenuMember_LockShipNameScroll.Text = "艦名をスクロールしない(&S)";
+            this.MenuMember_LockShipNameScroll.Click += new System.EventHandler(this.MenuMember_LockShipNameScroll_Click);
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(296, 6);
+            // 
+            // MenuMember_CSVOutput
+            // 
+            this.MenuMember_CSVOutput.Name = "MenuMember_CSVOutput";
+            this.MenuMember_CSVOutput.Size = new System.Drawing.Size(299, 22);
+            this.MenuMember_CSVOutput.Text = "CSV出力(&O)...";
+            this.MenuMember_CSVOutput.Click += new System.EventHandler(this.MenuMember_CSVOutput_Click);
+            // 
+            // toolStripSeparator3
+            // 
+            this.toolStripSeparator3.Name = "toolStripSeparator3";
+            this.toolStripSeparator3.Size = new System.Drawing.Size(296, 6);
+            // 
+            // MenuMember_Delete
+            // 
+            this.MenuMember_Delete.Name = "MenuMember_Delete";
+            this.MenuMember_Delete.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+            this.MenuMember_Delete.Size = new System.Drawing.Size(299, 22);
+            this.MenuMember_Delete.Text = "削除(&D)";
+            this.MenuMember_Delete.Click += new System.EventHandler(this.MenuMember_Delete_Click);
+            // 
+            // MenuGroup
+            // 
+            this.MenuGroup.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.MenuGroup_Add,
             this.MenuGroup_Rename,
             this.MenuGroup_Delete,
             this.toolStripSeparator4,
             this.MenuGroup_AutoUpdate,
             this.MenuGroup_ShowStatusBar});
-			this.MenuGroup.Name = "MenuGroup";
-			this.MenuGroup.Size = new System.Drawing.Size(221, 142);
-			this.MenuGroup.Opening += new System.ComponentModel.CancelEventHandler(this.MenuGroup_Opening);
-			// 
-			// MenuGroup_Add
-			// 
-			this.MenuGroup_Add.Name = "MenuGroup_Add";
-			this.MenuGroup_Add.Size = new System.Drawing.Size(220, 22);
-			this.MenuGroup_Add.Text = "グループを追加(&A)";
-			this.MenuGroup_Add.Click += new System.EventHandler(this.MenuGroup_Add_Click);
-			// 
-			// MenuGroup_Rename
-			// 
-			this.MenuGroup_Rename.Name = "MenuGroup_Rename";
-			this.MenuGroup_Rename.Size = new System.Drawing.Size(220, 22);
-			this.MenuGroup_Rename.Text = "グループ名の変更(&R)...";
-			this.MenuGroup_Rename.Click += new System.EventHandler(this.MenuGroup_Rename_Click);
-			// 
-			// MenuGroup_Delete
-			// 
-			this.MenuGroup_Delete.Name = "MenuGroup_Delete";
-			this.MenuGroup_Delete.Size = new System.Drawing.Size(220, 22);
-			this.MenuGroup_Delete.Text = "グループを削除(&D)";
-			this.MenuGroup_Delete.Click += new System.EventHandler(this.MenuGroup_Delete_Click);
-			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(217, 6);
-			// 
-			// MenuGroup_AutoUpdate
-			// 
-			this.MenuGroup_AutoUpdate.CheckOnClick = true;
-			this.MenuGroup_AutoUpdate.Name = "MenuGroup_AutoUpdate";
-			this.MenuGroup_AutoUpdate.Size = new System.Drawing.Size(220, 22);
-			this.MenuGroup_AutoUpdate.Text = "自動更新する";
-			// 
-			// MenuGroup_ShowStatusBar
-			// 
-			this.MenuGroup_ShowStatusBar.Checked = true;
-			this.MenuGroup_ShowStatusBar.CheckOnClick = true;
-			this.MenuGroup_ShowStatusBar.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.MenuGroup_ShowStatusBar.Name = "MenuGroup_ShowStatusBar";
-			this.MenuGroup_ShowStatusBar.Size = new System.Drawing.Size(220, 22);
-			this.MenuGroup_ShowStatusBar.Text = "ステータスバーを表示する";
-			this.MenuGroup_ShowStatusBar.CheckedChanged += new System.EventHandler(this.MenuGroup_ShowStatusBar_CheckedChanged);
-			// 
-			// splitContainer1
-			// 
-			this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-			this.splitContainer1.Location = new System.Drawing.Point(0, 0);
-			this.splitContainer1.Name = "splitContainer1";
-			this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
-			// 
-			// splitContainer1.Panel1
-			// 
-			this.splitContainer1.Panel1.Controls.Add(this.TabPanel);
-			// 
-			// splitContainer1.Panel2
-			// 
-			this.splitContainer1.Panel2.Controls.Add(this.ShipView);
-			this.splitContainer1.Panel2.Controls.Add(this.StatusBar);
-			this.splitContainer1.Size = new System.Drawing.Size(300, 200);
-			this.splitContainer1.SplitterDistance = 40;
-			this.splitContainer1.TabIndex = 1;
-			// 
-			// TabPanel
-			// 
-			this.TabPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.MenuGroup.Name = "MenuGroup";
+            this.MenuGroup.Size = new System.Drawing.Size(221, 120);
+            this.MenuGroup.Opening += new System.ComponentModel.CancelEventHandler(this.MenuGroup_Opening);
+            // 
+            // MenuGroup_Add
+            // 
+            this.MenuGroup_Add.Name = "MenuGroup_Add";
+            this.MenuGroup_Add.Size = new System.Drawing.Size(220, 22);
+            this.MenuGroup_Add.Text = "グループを追加(&A)";
+            this.MenuGroup_Add.Click += new System.EventHandler(this.MenuGroup_Add_Click);
+            // 
+            // MenuGroup_Rename
+            // 
+            this.MenuGroup_Rename.Name = "MenuGroup_Rename";
+            this.MenuGroup_Rename.Size = new System.Drawing.Size(220, 22);
+            this.MenuGroup_Rename.Text = "グループ名の変更(&R)...";
+            this.MenuGroup_Rename.Click += new System.EventHandler(this.MenuGroup_Rename_Click);
+            // 
+            // MenuGroup_Delete
+            // 
+            this.MenuGroup_Delete.Name = "MenuGroup_Delete";
+            this.MenuGroup_Delete.Size = new System.Drawing.Size(220, 22);
+            this.MenuGroup_Delete.Text = "グループを削除(&D)";
+            this.MenuGroup_Delete.Click += new System.EventHandler(this.MenuGroup_Delete_Click);
+            // 
+            // toolStripSeparator4
+            // 
+            this.toolStripSeparator4.Name = "toolStripSeparator4";
+            this.toolStripSeparator4.Size = new System.Drawing.Size(217, 6);
+            // 
+            // MenuGroup_AutoUpdate
+            // 
+            this.MenuGroup_AutoUpdate.CheckOnClick = true;
+            this.MenuGroup_AutoUpdate.Name = "MenuGroup_AutoUpdate";
+            this.MenuGroup_AutoUpdate.Size = new System.Drawing.Size(220, 22);
+            this.MenuGroup_AutoUpdate.Text = "自動更新する";
+            // 
+            // MenuGroup_ShowStatusBar
+            // 
+            this.MenuGroup_ShowStatusBar.Checked = true;
+            this.MenuGroup_ShowStatusBar.CheckOnClick = true;
+            this.MenuGroup_ShowStatusBar.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.MenuGroup_ShowStatusBar.Name = "MenuGroup_ShowStatusBar";
+            this.MenuGroup_ShowStatusBar.Size = new System.Drawing.Size(220, 22);
+            this.MenuGroup_ShowStatusBar.Text = "ステータスバーを表示する";
+            this.MenuGroup_ShowStatusBar.CheckedChanged += new System.EventHandler(this.MenuGroup_ShowStatusBar_CheckedChanged);
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.TabPanel);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.ShipView);
+            this.splitContainer1.Panel2.Controls.Add(this.StatusBar);
+            this.splitContainer1.Size = new System.Drawing.Size(300, 200);
+            this.splitContainer1.SplitterDistance = 40;
+            this.splitContainer1.TabIndex = 1;
+            // 
+            // TabPanel
+            // 
+            this.TabPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.TabPanel.AutoScroll = true;
-			this.TabPanel.ContextMenuStrip = this.MenuGroup;
-			this.TabPanel.Location = new System.Drawing.Point(0, 0);
-			this.TabPanel.Name = "TabPanel";
-			this.TabPanel.Size = new System.Drawing.Size(300, 40);
-			this.TabPanel.TabIndex = 0;
-			this.TabPanel.DragDrop += new System.Windows.Forms.DragEventHandler(this.TabPanel_DragDrop);
-			this.TabPanel.DragEnter += new System.Windows.Forms.DragEventHandler(this.TabPanel_DragEnter);
-			this.TabPanel.QueryContinueDrag += new System.Windows.Forms.QueryContinueDragEventHandler(this.TabPanel_QueryContinueDrag);
-			this.TabPanel.DoubleClick += new System.EventHandler(this.TabPanel_DoubleClick);
-			// 
-			// StatusBar
-			// 
-			this.StatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.TabPanel.AutoScroll = true;
+            this.TabPanel.ContextMenuStrip = this.MenuGroup;
+            this.TabPanel.Location = new System.Drawing.Point(0, 0);
+            this.TabPanel.Name = "TabPanel";
+            this.TabPanel.Size = new System.Drawing.Size(300, 40);
+            this.TabPanel.TabIndex = 0;
+            this.TabPanel.DragDrop += new System.Windows.Forms.DragEventHandler(this.TabPanel_DragDrop);
+            this.TabPanel.DragEnter += new System.Windows.Forms.DragEventHandler(this.TabPanel_DragEnter);
+            this.TabPanel.QueryContinueDrag += new System.Windows.Forms.QueryContinueDragEventHandler(this.TabPanel_QueryContinueDrag);
+            this.TabPanel.DoubleClick += new System.EventHandler(this.TabPanel_DoubleClick);
+            // 
+            // StatusBar
+            // 
+            this.StatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.Status_ShipCount,
             this.Status_LevelTotal,
             this.Status_LevelAverage});
-			this.StatusBar.Location = new System.Drawing.Point(0, 134);
-			this.StatusBar.Name = "StatusBar";
-			this.StatusBar.Size = new System.Drawing.Size(300, 22);
-			this.StatusBar.SizingGrip = false;
-			this.StatusBar.TabIndex = 1;
-			this.StatusBar.Text = "statusStrip1";
-			// 
-			// Status_ShipCount
-			// 
-			this.Status_ShipCount.Name = "Status_ShipCount";
-			this.Status_ShipCount.Size = new System.Drawing.Size(0, 17);
-			// 
-			// Status_LevelTotal
-			// 
-			this.Status_LevelTotal.Name = "Status_LevelTotal";
-			this.Status_LevelTotal.Size = new System.Drawing.Size(0, 17);
-			// 
-			// Status_LevelAverage
-			// 
-			this.Status_LevelAverage.Name = "Status_LevelAverage";
-			this.Status_LevelAverage.Size = new System.Drawing.Size(0, 17);
-			// 
-			// FormShipGroup
-			// 
-			this.AutoHidePortion = 150D;
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-			this.ClientSize = new System.Drawing.Size(300, 200);
-			this.Controls.Add(this.splitContainer1);
-			this.DoubleBuffered = true;
-			this.Font = new System.Drawing.Font("Meiryo UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
-			this.HideOnClose = true;
-			this.Name = "FormShipGroup";
-			this.Text = "グループ";
-			this.Load += new System.EventHandler(this.FormShipGroup_Load);
-			((System.ComponentModel.ISupportInitialize)(this.ShipView)).EndInit();
-			this.MenuMember.ResumeLayout(false);
-			this.MenuGroup.ResumeLayout(false);
-			this.splitContainer1.Panel1.ResumeLayout(false);
-			this.splitContainer1.Panel2.ResumeLayout(false);
-			this.splitContainer1.Panel2.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-			this.splitContainer1.ResumeLayout(false);
-			this.StatusBar.ResumeLayout(false);
-			this.StatusBar.PerformLayout();
-			this.ResumeLayout(false);
+            this.StatusBar.Location = new System.Drawing.Point(0, 134);
+            this.StatusBar.Name = "StatusBar";
+            this.StatusBar.Size = new System.Drawing.Size(300, 22);
+            this.StatusBar.SizingGrip = false;
+            this.StatusBar.TabIndex = 1;
+            this.StatusBar.Text = "statusStrip1";
+            // 
+            // Status_ShipCount
+            // 
+            this.Status_ShipCount.Name = "Status_ShipCount";
+            this.Status_ShipCount.Size = new System.Drawing.Size(0, 17);
+            // 
+            // Status_LevelTotal
+            // 
+            this.Status_LevelTotal.Name = "Status_LevelTotal";
+            this.Status_LevelTotal.Size = new System.Drawing.Size(0, 17);
+            // 
+            // Status_LevelAverage
+            // 
+            this.Status_LevelAverage.Name = "Status_LevelAverage";
+            this.Status_LevelAverage.Size = new System.Drawing.Size(0, 17);
+            // 
+            // MenuMember_AddCurrentFleet_Group
+            // 
+            this.MenuMember_AddCurrentFleet_Group.Name = "MenuMember_AddCurrentFleet_Group";
+            this.MenuMember_AddCurrentFleet_Group.Size = new System.Drawing.Size(299, 22);
+            this.MenuMember_AddCurrentFleet_Group.Text = "このグループに現在の艦隊を追加(&G)";
+            // 
+            // FormShipGroup
+            // 
+            this.AutoHidePortion = 150D;
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            this.ClientSize = new System.Drawing.Size(300, 200);
+            this.Controls.Add(this.splitContainer1);
+            this.DoubleBuffered = true;
+            this.Font = new System.Drawing.Font("Meiryo UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.HideOnClose = true;
+            this.Name = "FormShipGroup";
+            this.Text = "グループ";
+            this.Load += new System.EventHandler(this.FormShipGroup_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.ShipView)).EndInit();
+            this.MenuMember.ResumeLayout(false);
+            this.MenuGroup.ResumeLayout(false);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            this.splitContainer1.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.StatusBar.ResumeLayout(false);
+            this.StatusBar.PerformLayout();
+            this.ResumeLayout(false);
 
 		}
 
@@ -708,5 +716,6 @@
 		private System.Windows.Forms.ToolStripStatusLabel Status_LevelTotal;
 		private System.Windows.Forms.ToolStripStatusLabel Status_LevelAverage;
 		private System.Windows.Forms.ToolStripMenuItem MenuGroup_ShowStatusBar;
+        private System.Windows.Forms.ToolStripMenuItem MenuMember_AddCurrentFleet_Group;
 	}
 }

--- a/ElectronicObserver/Window/FormShipGroup.cs
+++ b/ElectronicObserver/Window/FormShipGroup.cs
@@ -239,7 +239,6 @@ namespace ElectronicObserver.Window {
 		private void ApplyGroupData( ImageLabel target ) {
 
 			if ( target != null ) {
-				target.BackColor = TabInactiveColor;
 
 				//ソート順の保持
 				if ( KCDatabase.Instance.Ships.Count == 0 )
@@ -265,8 +264,167 @@ namespace ElectronicObserver.Window {
 		}
 
 
+        /// <summary>
+        /// 指定したタブのグループのShipViewを作成する。
+        /// </summary>
+        /// <param name="target">作成するビューのグループデータ</param>
+        private void BuildShipView(ImageLabel target)
+        {
+            if (target == null)
+                return;
+
+            int groupID = (int)target.Tag;
+            ShipGroupData group = KCDatabase.Instance.ShipGroup[groupID];
+
+            ShipView.SuspendLayout();
+
+            ShipView.Rows.Clear();
+
+            IEnumerable<ShipData> ships = group.MembersInstance;
+            List<DataGridViewRow> rows = new List<DataGridViewRow>(ships.Count());
+
+            foreach (ShipData ship in ships)
+            {
+
+                if (ship == null) continue;
+                DataGridViewRow row = new DataGridViewRow();
+                row.CreateCells(ShipView);
+                row.SetValues(
+                    ship.MasterID,
+                    ship.MasterShip.ShipType,
+                    ship.MasterShip.Name,
+                    ship.Level,
+                    ship.ExpTotal,
+                    ship.ExpNext,
+                    ship.ExpNextRemodel,
+                    new Fraction(ship.HPCurrent, ship.HPMax),
+                    ship.Condition,
+                    new Fraction(ship.Fuel, ship.MasterShip.Fuel),
+                    new Fraction(ship.Ammo, ship.MasterShip.Ammo),
+                    GetEquipmentString(ship, 0),
+                    GetEquipmentString(ship, 1),
+                    GetEquipmentString(ship, 2),
+                    GetEquipmentString(ship, 3),
+                    GetEquipmentString(ship, 4),
+                    ship.FleetWithIndex,
+                    ship.RepairingDockID == -1 ? ship.RepairTime : -1000 + ship.RepairingDockID,
+                    ship.FirepowerBase,
+                    ship.FirepowerRemain,
+                    ship.TorpedoBase,
+                    ship.TorpedoRemain,
+                    ship.AABase,
+                    ship.AARemain,
+                    ship.ArmorBase,
+                    ship.ArmorRemain,
+                    ship.ASWBase,
+                    ship.EvasionBase,
+                    ship.LOSBase,
+                    ship.LuckBase,
+                    ship.LuckRemain,
+                    ship.IsLocked,
+                    ship.SallyArea
+                    );
+
+                row.Cells[ShipView_Name.Index].Tag = ship.ShipID;
+                row.Cells[ShipView_Level.Index].Tag = ship.ExpTotal;
+
+                {
+                    DataGridViewCellStyle cs;
+                    double hprate = (double)ship.HPCurrent / Math.Max(ship.HPMax, 1);
+                    if (hprate <= 0.25)
+                        cs = CSRedRight;
+                    else if (hprate <= 0.50)
+                        cs = CSOrangeRight;
+                    else if (hprate <= 0.75)
+                        cs = CSYellowRight;
+                    else if (hprate < 1.00)
+                        cs = CSGreenRight;
+                    else
+                        cs = CSDefaultRight;
+
+                    row.Cells[ShipView_HP.Index].Style = cs;
+                }
+                {
+                    DataGridViewCellStyle cs;
+                    if (ship.Condition < 20)
+                        cs = CSRedRight;
+                    else if (ship.Condition < 30)
+                        cs = CSOrangeRight;
+                    else if (ship.Condition < Utility.Configuration.Config.Control.ConditionBorder)
+                        cs = CSYellowRight;
+                    else if (ship.Condition < 50)
+                        cs = CSDefaultRight;
+                    else
+                        cs = CSGreenRight;
+
+                    row.Cells[ShipView_Condition.Index].Style = cs;
+                }
+                row.Cells[ShipView_Fuel.Index].Style = ship.Fuel < ship.MasterShip.Fuel ? CSYellowRight : CSDefaultRight;
+                row.Cells[ShipView_Ammo.Index].Style = ship.Fuel < ship.MasterShip.Fuel ? CSYellowRight : CSDefaultRight;
+                {
+                    DataGridViewCellStyle cs;
+                    if (ship.RepairTime == 0)
+                        cs = CSDefaultRight;
+                    else if (ship.RepairTime < 1000 * 60 * 60)
+                        cs = CSYellowRight;
+                    else if (ship.RepairTime < 1000 * 60 * 60 * 6)
+                        cs = CSOrangeRight;
+                    else
+                        cs = CSRedRight;
+
+                    row.Cells[ShipView_RepairTime.Index].Style = cs;
+                }
+                row.Cells[ShipView_FirepowerRemain.Index].Style = ship.FirepowerRemain == 0 ? CSGrayRight : CSDefaultRight;
+                row.Cells[ShipView_TorpedoRemain.Index].Style = ship.TorpedoRemain == 0 ? CSGrayRight : CSDefaultRight;
+                row.Cells[ShipView_AARemain.Index].Style = ship.AARemain == 0 ? CSGrayRight : CSDefaultRight;
+                row.Cells[ShipView_ArmorRemain.Index].Style = ship.ArmorRemain == 0 ? CSGrayRight : CSDefaultRight;
+                row.Cells[ShipView_LuckRemain.Index].Style = ship.LuckRemain == 0 ? CSGrayRight : CSDefaultRight;
+
+                row.Cells[ShipView_Locked.Index].Style = ship.IsLocked ? CSIsLocked : CSDefaultCenter;
+
+
+                rows.Add(row);
+
+            }
+
+            for (int i = 0; i < rows.Count; i++)
+                rows[i].Tag = i;
+
+            ShipView.Rows.AddRange(rows.ToArray());
+
+
+            {
+                int columnCount = ShipView.Columns.Count;
+                if (group.ColumnFilter != null) columnCount = Math.Min(columnCount, group.ColumnFilter.Count);
+                if (group.ColumnWidth != null) columnCount = Math.Min(columnCount, group.ColumnWidth.Count);
+
+
+                for (int i = 0; i < columnCount; i++)
+                {
+                    ShipView.Columns[i].Visible = group.ColumnFilter[i];
+                    ShipView.Columns[i].Width = group.ColumnWidth[i];
+                }
+            }
+
+            SetColumnAutoSize(group.ColumnAutoSize);
+            SetLockShipNameScroll(group.LockShipNameScroll);
+
+
+            ShipView.ResumeLayout();
+
+
+            //status bar
+            if (KCDatabase.Instance.Ships.Count > 0)
+            {
+                Status_ShipCount.Text = string.Format("所属: {0}隻", group.Members.Count);
+                Status_LevelTotal.Text = string.Format("合計Lv: {0}", group.MembersInstance.Where(s => s != null).Sum(s => s.Level));
+                Status_LevelAverage.Text = string.Format("平均Lv: {0:F2}", group.Members.Count > 0 ? group.MembersInstance.Where(s => s != null).Average(s => s.Level) : 0);
+            }
+        }
+
+
 		/// <summary>
-		/// ShipViewを更新します。
+		/// ShipViewを指定したタブに切り替えます。
 		/// </summary>
 		private void ChangeShipView( ImageLabel target ) {
 
@@ -288,150 +446,10 @@ namespace ElectronicObserver.Window {
 				group.Members = group.Members.Intersect( KCDatabase.Instance.Ships.Keys ).Union( KCDatabase.Instance.Ships.Keys ).Distinct().ToList();
 			}
 
-
-			ShipView.SuspendLayout();
-
-			ShipView.Rows.Clear();
-
-			IEnumerable<ShipData> ships = group.MembersInstance;
-			List<DataGridViewRow> rows = new List<DataGridViewRow>( ships.Count() );
-
-			foreach ( ShipData ship in ships ) {
-
-				if ( ship == null ) continue;
-				DataGridViewRow row = new DataGridViewRow();
-				row.CreateCells( ShipView );
-				row.SetValues(
-					ship.MasterID,
-					ship.MasterShip.ShipType,
-					ship.MasterShip.Name,
-					ship.Level,
-					ship.ExpTotal,
-					ship.ExpNext,
-					ship.ExpNextRemodel,
-					new Fraction( ship.HPCurrent, ship.HPMax ),
-					ship.Condition,
-					new Fraction( ship.Fuel, ship.MasterShip.Fuel ),
-					new Fraction( ship.Ammo, ship.MasterShip.Ammo ),
-					GetEquipmentString( ship, 0 ),
-					GetEquipmentString( ship, 1 ),
-					GetEquipmentString( ship, 2 ),
-					GetEquipmentString( ship, 3 ),
-					GetEquipmentString( ship, 4 ),
-					ship.FleetWithIndex,
-					ship.RepairingDockID == -1 ? ship.RepairTime : -1000 + ship.RepairingDockID,
-					ship.FirepowerBase,
-					ship.FirepowerRemain,
-					ship.TorpedoBase,
-					ship.TorpedoRemain,
-					ship.AABase,
-					ship.AARemain,
-					ship.ArmorBase,
-					ship.ArmorRemain,
-					ship.ASWBase,
-					ship.EvasionBase,
-					ship.LOSBase,
-					ship.LuckBase,
-					ship.LuckRemain,
-					ship.IsLocked,
-					ship.SallyArea
-					);
-
-				row.Cells[ShipView_Name.Index].Tag = ship.ShipID;
-				row.Cells[ShipView_Level.Index].Tag = ship.ExpTotal;
-
-				{
-					DataGridViewCellStyle cs;
-					double hprate = (double)ship.HPCurrent / Math.Max( ship.HPMax, 1 );
-					if ( hprate <= 0.25 )
-						cs = CSRedRight;
-					else if ( hprate <= 0.50 )
-						cs = CSOrangeRight;
-					else if ( hprate <= 0.75 )
-						cs = CSYellowRight;
-					else if ( hprate < 1.00 )
-						cs = CSGreenRight;
-					else
-						cs = CSDefaultRight;
-
-					row.Cells[ShipView_HP.Index].Style = cs;
-				}
-				{
-					DataGridViewCellStyle cs;
-					if ( ship.Condition < 20 )
-						cs = CSRedRight;
-					else if ( ship.Condition < 30 )
-						cs = CSOrangeRight;
-					else if ( ship.Condition < Utility.Configuration.Config.Control.ConditionBorder )
-						cs = CSYellowRight;
-					else if ( ship.Condition < 50 )
-						cs = CSDefaultRight;
-					else
-						cs = CSGreenRight;
-
-					row.Cells[ShipView_Condition.Index].Style = cs;
-				}
-				row.Cells[ShipView_Fuel.Index].Style = ship.Fuel < ship.MasterShip.Fuel ? CSYellowRight : CSDefaultRight;
-				row.Cells[ShipView_Ammo.Index].Style = ship.Fuel < ship.MasterShip.Fuel ? CSYellowRight : CSDefaultRight;
-				{
-					DataGridViewCellStyle cs;
-					if ( ship.RepairTime == 0 )
-						cs = CSDefaultRight;
-					else if ( ship.RepairTime < 1000 * 60 * 60 )
-						cs = CSYellowRight;
-					else if ( ship.RepairTime < 1000 * 60 * 60 * 6 )
-						cs = CSOrangeRight;
-					else
-						cs = CSRedRight;
-
-					row.Cells[ShipView_RepairTime.Index].Style = cs;
-				}
-				row.Cells[ShipView_FirepowerRemain.Index].Style = ship.FirepowerRemain == 0 ? CSGrayRight : CSDefaultRight;
-				row.Cells[ShipView_TorpedoRemain.Index].Style = ship.TorpedoRemain == 0 ? CSGrayRight : CSDefaultRight;
-				row.Cells[ShipView_AARemain.Index].Style = ship.AARemain == 0 ? CSGrayRight : CSDefaultRight;
-				row.Cells[ShipView_ArmorRemain.Index].Style = ship.ArmorRemain == 0 ? CSGrayRight : CSDefaultRight;
-				row.Cells[ShipView_LuckRemain.Index].Style = ship.LuckRemain == 0 ? CSGrayRight : CSDefaultRight;
-
-				row.Cells[ShipView_Locked.Index].Style = ship.IsLocked ? CSIsLocked : CSDefaultCenter;
-
-
-				rows.Add( row );
-
-			}
-
-			for ( int i = 0; i < rows.Count; i++ )
-				rows[i].Tag = i;
-
-			ShipView.Rows.AddRange( rows.ToArray() );
-
-
-			{
-				int columnCount = ShipView.Columns.Count;
-				if ( group.ColumnFilter != null ) columnCount = Math.Min( columnCount, group.ColumnFilter.Count );
-				if ( group.ColumnWidth != null ) columnCount = Math.Min( columnCount, group.ColumnWidth.Count );
-
-
-				for ( int i = 0; i < columnCount; i++ ) {
-					ShipView.Columns[i].Visible = group.ColumnFilter[i];
-					ShipView.Columns[i].Width = group.ColumnWidth[i];
-				}
-			}
-
-			SetColumnAutoSize( group.ColumnAutoSize );
-			SetLockShipNameScroll( group.LockShipNameScroll );
-
-
-			ShipView.ResumeLayout();
-
-
-			//status bar
-			if ( KCDatabase.Instance.Ships.Count > 0 ) {
-				Status_ShipCount.Text = string.Format( "所属: {0}隻", group.Members.Count );
-				Status_LevelTotal.Text = string.Format( "合計Lv: {0}", group.MembersInstance.Where( s => s != null ).Sum( s => s.Level ) );
-				Status_LevelAverage.Text = string.Format( "平均Lv: {0:F2}", group.Members.Count > 0 ? group.MembersInstance.Where( s => s != null ).Average( s => s.Level ) : 0 );
-			}
-
+            if( SelectedTab != null )
+                SelectedTab.BackColor = TabInactiveColor;
 			SelectedTab = target;
+            BuildShipView(SelectedTab);
 			SelectedTab.BackColor = TabActiveColor;
 
 		}

--- a/ElectronicObserver/Window/FormShipGroup.cs
+++ b/ElectronicObserver/Window/FormShipGroup.cs
@@ -265,6 +265,112 @@ namespace ElectronicObserver.Window {
 
 
         /// <summary>
+        /// ShipView用の新しい行のインスタンスを作成する
+        /// </summary>
+        /// <param name="ship">追加する艦娘データ</param>
+        /// <returns>新しい行</returns>
+        private DataGridViewRow CreateShipViewRow(ShipData ship)
+        {
+            DataGridViewRow row = new DataGridViewRow();
+            row.CreateCells(ShipView);
+            row.SetValues(
+                ship.MasterID,
+                ship.MasterShip.ShipType,
+                ship.MasterShip.Name,
+                ship.Level,
+                ship.ExpTotal,
+                ship.ExpNext,
+                ship.ExpNextRemodel,
+                new Fraction(ship.HPCurrent, ship.HPMax),
+                ship.Condition,
+                new Fraction(ship.Fuel, ship.MasterShip.Fuel),
+                new Fraction(ship.Ammo, ship.MasterShip.Ammo),
+                GetEquipmentString(ship, 0),
+                GetEquipmentString(ship, 1),
+                GetEquipmentString(ship, 2),
+                GetEquipmentString(ship, 3),
+                GetEquipmentString(ship, 4),
+                ship.FleetWithIndex,
+                ship.RepairingDockID == -1 ? ship.RepairTime : -1000 + ship.RepairingDockID,
+                ship.FirepowerBase,
+                ship.FirepowerRemain,
+                ship.TorpedoBase,
+                ship.TorpedoRemain,
+                ship.AABase,
+                ship.AARemain,
+                ship.ArmorBase,
+                ship.ArmorRemain,
+                ship.ASWBase,
+                ship.EvasionBase,
+                ship.LOSBase,
+                ship.LuckBase,
+                ship.LuckRemain,
+                ship.IsLocked,
+                ship.SallyArea
+                );
+
+            row.Cells[ShipView_Name.Index].Tag = ship.ShipID;
+            row.Cells[ShipView_Level.Index].Tag = ship.ExpTotal;
+
+            {
+                DataGridViewCellStyle cs;
+                double hprate = (double)ship.HPCurrent / Math.Max(ship.HPMax, 1);
+                if (hprate <= 0.25)
+                    cs = CSRedRight;
+                else if (hprate <= 0.50)
+                    cs = CSOrangeRight;
+                else if (hprate <= 0.75)
+                    cs = CSYellowRight;
+                else if (hprate < 1.00)
+                    cs = CSGreenRight;
+                else
+                    cs = CSDefaultRight;
+
+                row.Cells[ShipView_HP.Index].Style = cs;
+            }
+            {
+                DataGridViewCellStyle cs;
+                if (ship.Condition < 20)
+                    cs = CSRedRight;
+                else if (ship.Condition < 30)
+                    cs = CSOrangeRight;
+                else if (ship.Condition < Utility.Configuration.Config.Control.ConditionBorder)
+                    cs = CSYellowRight;
+                else if (ship.Condition < 50)
+                    cs = CSDefaultRight;
+                else
+                    cs = CSGreenRight;
+
+                row.Cells[ShipView_Condition.Index].Style = cs;
+            }
+            row.Cells[ShipView_Fuel.Index].Style = ship.Fuel < ship.MasterShip.Fuel ? CSYellowRight : CSDefaultRight;
+            row.Cells[ShipView_Ammo.Index].Style = ship.Fuel < ship.MasterShip.Fuel ? CSYellowRight : CSDefaultRight;
+            {
+                DataGridViewCellStyle cs;
+                if (ship.RepairTime == 0)
+                    cs = CSDefaultRight;
+                else if (ship.RepairTime < 1000 * 60 * 60)
+                    cs = CSYellowRight;
+                else if (ship.RepairTime < 1000 * 60 * 60 * 6)
+                    cs = CSOrangeRight;
+                else
+                    cs = CSRedRight;
+
+                row.Cells[ShipView_RepairTime.Index].Style = cs;
+            }
+            row.Cells[ShipView_FirepowerRemain.Index].Style = ship.FirepowerRemain == 0 ? CSGrayRight : CSDefaultRight;
+            row.Cells[ShipView_TorpedoRemain.Index].Style = ship.TorpedoRemain == 0 ? CSGrayRight : CSDefaultRight;
+            row.Cells[ShipView_AARemain.Index].Style = ship.AARemain == 0 ? CSGrayRight : CSDefaultRight;
+            row.Cells[ShipView_ArmorRemain.Index].Style = ship.ArmorRemain == 0 ? CSGrayRight : CSDefaultRight;
+            row.Cells[ShipView_LuckRemain.Index].Style = ship.LuckRemain == 0 ? CSGrayRight : CSDefaultRight;
+
+            row.Cells[ShipView_Locked.Index].Style = ship.IsLocked ? CSIsLocked : CSDefaultCenter;
+
+            return row;
+        }
+
+
+        /// <summary>
         /// 指定したタブのグループのShipViewを作成する。
         /// </summary>
         /// <param name="target">作成するビューのグループデータ</param>
@@ -287,102 +393,8 @@ namespace ElectronicObserver.Window {
             {
 
                 if (ship == null) continue;
-                DataGridViewRow row = new DataGridViewRow();
-                row.CreateCells(ShipView);
-                row.SetValues(
-                    ship.MasterID,
-                    ship.MasterShip.ShipType,
-                    ship.MasterShip.Name,
-                    ship.Level,
-                    ship.ExpTotal,
-                    ship.ExpNext,
-                    ship.ExpNextRemodel,
-                    new Fraction(ship.HPCurrent, ship.HPMax),
-                    ship.Condition,
-                    new Fraction(ship.Fuel, ship.MasterShip.Fuel),
-                    new Fraction(ship.Ammo, ship.MasterShip.Ammo),
-                    GetEquipmentString(ship, 0),
-                    GetEquipmentString(ship, 1),
-                    GetEquipmentString(ship, 2),
-                    GetEquipmentString(ship, 3),
-                    GetEquipmentString(ship, 4),
-                    ship.FleetWithIndex,
-                    ship.RepairingDockID == -1 ? ship.RepairTime : -1000 + ship.RepairingDockID,
-                    ship.FirepowerBase,
-                    ship.FirepowerRemain,
-                    ship.TorpedoBase,
-                    ship.TorpedoRemain,
-                    ship.AABase,
-                    ship.AARemain,
-                    ship.ArmorBase,
-                    ship.ArmorRemain,
-                    ship.ASWBase,
-                    ship.EvasionBase,
-                    ship.LOSBase,
-                    ship.LuckBase,
-                    ship.LuckRemain,
-                    ship.IsLocked,
-                    ship.SallyArea
-                    );
 
-                row.Cells[ShipView_Name.Index].Tag = ship.ShipID;
-                row.Cells[ShipView_Level.Index].Tag = ship.ExpTotal;
-
-                {
-                    DataGridViewCellStyle cs;
-                    double hprate = (double)ship.HPCurrent / Math.Max(ship.HPMax, 1);
-                    if (hprate <= 0.25)
-                        cs = CSRedRight;
-                    else if (hprate <= 0.50)
-                        cs = CSOrangeRight;
-                    else if (hprate <= 0.75)
-                        cs = CSYellowRight;
-                    else if (hprate < 1.00)
-                        cs = CSGreenRight;
-                    else
-                        cs = CSDefaultRight;
-
-                    row.Cells[ShipView_HP.Index].Style = cs;
-                }
-                {
-                    DataGridViewCellStyle cs;
-                    if (ship.Condition < 20)
-                        cs = CSRedRight;
-                    else if (ship.Condition < 30)
-                        cs = CSOrangeRight;
-                    else if (ship.Condition < Utility.Configuration.Config.Control.ConditionBorder)
-                        cs = CSYellowRight;
-                    else if (ship.Condition < 50)
-                        cs = CSDefaultRight;
-                    else
-                        cs = CSGreenRight;
-
-                    row.Cells[ShipView_Condition.Index].Style = cs;
-                }
-                row.Cells[ShipView_Fuel.Index].Style = ship.Fuel < ship.MasterShip.Fuel ? CSYellowRight : CSDefaultRight;
-                row.Cells[ShipView_Ammo.Index].Style = ship.Fuel < ship.MasterShip.Fuel ? CSYellowRight : CSDefaultRight;
-                {
-                    DataGridViewCellStyle cs;
-                    if (ship.RepairTime == 0)
-                        cs = CSDefaultRight;
-                    else if (ship.RepairTime < 1000 * 60 * 60)
-                        cs = CSYellowRight;
-                    else if (ship.RepairTime < 1000 * 60 * 60 * 6)
-                        cs = CSOrangeRight;
-                    else
-                        cs = CSRedRight;
-
-                    row.Cells[ShipView_RepairTime.Index].Style = cs;
-                }
-                row.Cells[ShipView_FirepowerRemain.Index].Style = ship.FirepowerRemain == 0 ? CSGrayRight : CSDefaultRight;
-                row.Cells[ShipView_TorpedoRemain.Index].Style = ship.TorpedoRemain == 0 ? CSGrayRight : CSDefaultRight;
-                row.Cells[ShipView_AARemain.Index].Style = ship.AARemain == 0 ? CSGrayRight : CSDefaultRight;
-                row.Cells[ShipView_ArmorRemain.Index].Style = ship.ArmorRemain == 0 ? CSGrayRight : CSDefaultRight;
-                row.Cells[ShipView_LuckRemain.Index].Style = ship.LuckRemain == 0 ? CSGrayRight : CSDefaultRight;
-
-                row.Cells[ShipView_Locked.Index].Style = ship.IsLocked ? CSIsLocked : CSDefaultCenter;
-
-
+                DataGridViewRow row = CreateShipViewRow(ship);
                 rows.Add(row);
 
             }


### PR DESCRIPTION
艦船グループのShipViewのコンテキストメニューで、編成中の艦隊をグループに追加する機能を追加しました。
ChangeShipViewメソッドがタブの切り替えとShipView構築で一体になっていたため、ShipView構築の部分を分離してBuildShipViewメソッドを作成し、上記機能に使用しています。