### PR TITLE
Fix/issue 28

### DIFF
--- a/ElectronicObserver/Window/FormMain.cs
+++ b/ElectronicObserver/Window/FormMain.cs
@@ -403,6 +403,8 @@ namespace ElectronicObserver.Window {
 
 			try {
 
+				CreateParentDirectories( path );
+
 				using ( var stream = File.Open( path, FileMode.Create ) )
 				using ( var archive = new ZipArchive( stream, ZipArchiveMode.Create ) ) {
 
@@ -424,7 +426,15 @@ namespace ElectronicObserver.Window {
 
 		}
 
+		private void CreateParentDirectories( string path ) {
 
+			var parents = Path.GetDirectoryName( path );
+
+			if ( !String.IsNullOrEmpty( parents ) ) {
+				Directory.CreateDirectory( parents );
+			}
+
+		}
 
 
 

--- a/ElectronicObserver/Window/FormMain.cs
+++ b/ElectronicObserver/Window/FormMain.cs
@@ -403,15 +403,14 @@ namespace ElectronicObserver.Window {
 
 			try {
 
-				using ( var stream = File.Open( path, FileMode.Create ) ) {
-					using ( var archive = new ZipArchive( stream, ZipArchiveMode.Create ) ) {
+				using ( var stream = File.Open( path, FileMode.Create ) )
+				using ( var archive = new ZipArchive( stream, ZipArchiveMode.Create ) ) {
 
-						using ( var layoutstream = archive.CreateEntry( "SubWindowLayout.xml" ).Open() ) {
-							SaveSubWindowsLayout( layoutstream );
-						}
-						using ( var placementstream = archive.CreateEntry( "WindowPlacement.xml" ).Open() ) {
-							WindowPlacementManager.SaveWindowPlacement( this, placementstream );
-						}
+					using ( var layoutstream = archive.CreateEntry( "SubWindowLayout.xml" ).Open() ) {
+						SaveSubWindowsLayout( layoutstream );
+					}
+					using ( var placementstream = archive.CreateEntry( "WindowPlacement.xml" ).Open() ) {
+						WindowPlacementManager.SaveWindowPlacement( this, placementstream );
 					}
 				}
 


### PR DESCRIPTION
#28 の問題を修正しました。

初回起動時は終了するまで設定ファイル類が保存されておらず、Settingsディレクトリが作成されていないために起きていたようなので、レイアウトファイルの保存の試行時にパス内のディレクトリを作成する処理を追加しました。

また、この変更により、「設定→ウィンドウ→レイアウトファイル」 の値を直接書き替え、存在しないディレクトリが含まれるパスとなった場合にも、保存に失敗しなくなっています。