### PR TITLE
カスタムフラッシュ品質/モードを許可する

### DIFF
--- a/ElectronicObserver/Utility/Configuration.cs
+++ b/ElectronicObserver/Utility/Configuration.cs
@@ -437,6 +437,16 @@ namespace ElectronicObserver.Utility {
 			public class ConfigFormBrowser : ConfigPartBase {
 
 				/// <summary>
+				/// flash parameter 'wmode'
+				/// </summary>
+				public string FlashWmode { get; set; }
+
+				/// <summary>
+				/// flash parameter 'quality'
+				/// </summary>
+				public string FlashQuality { get; set; }
+
+				/// <summary>
 				/// ブラウザの拡大率 10-1000(%)
 				/// </summary>
 				public int ZoomRate { get; set; }
@@ -494,6 +504,8 @@ namespace ElectronicObserver.Utility {
 
 
 				public ConfigFormBrowser() {
+					FlashWmode = "direct";
+					FlashQuality = "high";
 					ZoomRate = 100;
 					LogInPageURL = @"http://www.dmm.com/netgame_s/kancolle/";
 					IsEnabled = true;


### PR DESCRIPTION
デフォルトのフラッシュモードは「opaque」です。
それは、「direct」である場合に、より速くなる。

さらに、プレート上、「low」品質速い。
カスタムモード/品質を可能にする場合、ユーザーは非常に幸せになります。
