### PR TITLE
艦これ起動前に艦船グループのタブを選択した場合の問題を修正

### DIFF
--- a/ElectronicObserver/Window/FormShipGroup.cs
+++ b/ElectronicObserver/Window/FormShipGroup.cs
@@ -46,6 +46,8 @@ namespace ElectronicObserver.Window {
 		/// <summary>選択中のタブ</summary>
 		private ImageLabel SelectedTab = null;
 
+        /// <summary>艦これ起動前にタブを選択した場合はtrue</summary>
+        private bool IsTabSelectedBeforeBoot = false;
 
 		public FormShipGroup( FormMain parent ) {
 			InitializeComponent();
@@ -226,7 +228,13 @@ namespace ElectronicObserver.Window {
 		}
 
 		private void APIUpdated( string apiname, dynamic data ) {
-			if ( MenuGroup_AutoUpdate.Checked )
+            if ( IsTabSelectedBeforeBoot ) {
+                // 空のShipViewでKCDatabase.Instance.ShipGroupを上書きしてしまうのを防ぐため、
+                // 艦これ起動前にタブを選択した後の最初の艦船データ受信時は、ShipViewの構築を行う
+                BuildShipView( SelectedTab );
+                IsTabSelectedBeforeBoot = false;
+
+            }else if ( MenuGroup_AutoUpdate.Checked )
 				ChangeShipView( SelectedTab );
 		}
 
@@ -459,7 +467,12 @@ namespace ElectronicObserver.Window {
 
 			if ( SelectedTab != null )
 				SelectedTab.BackColor = TabInactiveColor;
-			SelectedTab = target;
+            
+            SelectedTab = target;
+            // 艦これ起動前にタブを選択した場合はフラグを立てておく(APIUpdatedで使う)
+            if ( KCDatabase.Instance.Ships.Count == 0 )
+                IsTabSelectedBeforeBoot = true;
+
 			BuildShipView( SelectedTab );
 			SelectedTab.BackColor = TabActiveColor;
 


### PR DESCRIPTION
艦これ起動前に艦船グループのタブを選択した場合、艦これ起動後に選択していたグループの所属艦情報が消滅してしまう問題を修正しました。