### PR TITLE
ユーザーはkancolle-db.netにデータを送信するように選択することができます

### DIFF
--- a/ElectronicObserver/ElectronicObserver.csproj
+++ b/ElectronicObserver/ElectronicObserver.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Notifier\NotifierRepair.cs" />
     <Compile Include="Notifier\NotifierExpedition.cs" />
     <Compile Include="Notifier\NotifierManager.cs" />
+    <Compile Include="Observer\APIKancolleDB.cs" />
     <Compile Include="Observer\kcsapi\api_get_member\material.cs" />
     <Compile Include="Observer\kcsapi\api_get_member\ship_deck.cs" />
     <Compile Include="Observer\kcsapi\api_req_kaisou\marriage.cs" />

--- a/ElectronicObserver/Observer/APIKancolleDB.cs
+++ b/ElectronicObserver/Observer/APIKancolleDB.cs
@@ -112,7 +112,9 @@ namespace ElectronicObserver.Observer {
 				using ( System.Net.WebClient wc = new System.Net.WebClient() ) {
 					System.Collections.Specialized.NameValueCollection post = new System.Collections.Specialized.NameValueCollection();
 					post.Add( "token", oauth );
-					post.Add( "agent", "LZXNXVGPejgSnEXLH2ur" );  // TODO: now it means 'KanColleViewer'
+					// agent key for 'ElectronicObserver'
+					// https://github.com/about518/kanColleDbPost/issues/3#issuecomment-105534030
+					post.Add( "agent", "L57Mi4hJeCYinbbBSH5K" );
 					post.Add( "url", url );
 					post.Add( "requestbody", request );
 					post.Add( "responsebody", response );
@@ -135,7 +137,7 @@ namespace ElectronicObserver.Observer {
 
 				string body =
 					"token=" + HttpUtility.UrlEncode( oauth ) + "&" +
-					"agent=LZXNXVGPejgSnEXLH2ur&" +	// TODO: now it means 'KanColleViewer'
+					"agent=L57Mi4hJeCYinbbBSH5K&" +	// agent key for 'ElectronicObserver'
 					"url=" + HttpUtility.UrlEncode( url ) + "&" +
 					"requestbody=" + HttpUtility.UrlEncode( request ) + "&" +
 					"responsebody=" + HttpUtility.UrlEncode( response.Replace( "svdata=", "" ) );

--- a/ElectronicObserver/Observer/APIKancolleDB.cs
+++ b/ElectronicObserver/Observer/APIKancolleDB.cs
@@ -1,4 +1,5 @@
-﻿using Fiddler;
+﻿using ElectronicObserver.Utility;
+using Fiddler;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -70,8 +71,7 @@ namespace ElectronicObserver.Observer {
 		/// <param name="oSession"></param>
 		public static void ExecuteSession( Session oSession ) {
 
-			if ( !Utility.Configuration.Config.Connection.SendDataToKancolleDB ||
-				Utility.Configuration.Config.Connection.SendKancolleDBApis == 0 ||
+			if ( Utility.Configuration.Config.Connection.SendKancolleDBApis == 0 ||
 				string.IsNullOrEmpty( Utility.Configuration.Config.Connection.SendKancolleOAuth ) ) {
 
 				return;
@@ -109,6 +109,7 @@ namespace ElectronicObserver.Observer {
 
 			try {
 
+				/*
 				using ( System.Net.WebClient wc = new System.Net.WebClient() ) {
 					System.Collections.Specialized.NameValueCollection post = new System.Collections.Specialized.NameValueCollection();
 					post.Add( "token", oauth );
@@ -129,11 +130,13 @@ namespace ElectronicObserver.Observer {
 
 					wc.UploadValuesAsync( new Uri( "http://api.kancolle-db.net/2/" ), post );
 				}
+				//*/
 
-				/*
-				var req = WebRequest.Create( "http://api.kancolle-db.net/2/" );
+				//*
+				var req = (HttpWebRequest)WebRequest.Create( "http://api.kancolle-db.net/2/" );
 				req.Method = "POST";
 				req.ContentType = "application/x-www-form-urlencoded";
+				req.UserAgent = "ElectronicObserver/v" + SoftwareInformation.VersionEnglish;
 
 				string body =
 					"token=" + HttpUtility.UrlEncode( oauth ) + "&" +
@@ -150,12 +153,16 @@ namespace ElectronicObserver.Observer {
 				}
 
 				using ( var resp = (HttpWebResponse)req.GetResponse() ) {
+
+#if DEBUG
 					using ( var respReader = new StreamReader(resp.GetResponseStream()) )
 					using ( var output = new StreamWriter( @"kancolle-db.log", true, Encoding.UTF8 ) ) {
 
-						output.WriteLine( "[{0}] - {1}: {2}", DateTime.Now, resp.StatusCode, respReader.ReadToEnd() );
+						output.WriteLine( "[{0}] - {1}: {2}", DateTime.Now, url, respReader.ReadToEnd() );
 
 					}
+#endif
+					Utility.Logger.Add( 1, string.Format( "{0}のデータを送信しました。", url.Substring( url.IndexOf( "kcsapi/" ) + 1 ) ) );
 				}
 				//*/
 

--- a/ElectronicObserver/Observer/APIKancolleDB.cs
+++ b/ElectronicObserver/Observer/APIKancolleDB.cs
@@ -1,0 +1,147 @@
+﻿using Fiddler;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace ElectronicObserver.Observer {
+	
+	public class APIKancolleDB {
+
+		public enum APIType : int {
+			PORT = 0,
+			SHIP2,
+			SHIP3,
+			KDOCK,
+			CHANGE,
+			CREATESHIP,
+			GETSHIP,
+			CREATEITEM,
+			START,
+			NEXT,
+			BATTLE,
+			BATTLE_MIDNIGHT,
+			BATTLE_SP_MIDNIGHT,
+			BATTLE_NIGHT_TO_DAY,
+			BATTLERESULT,
+			PRACTICE_BATTLE,
+			PRACTICE_BATTLERESULT,
+			COMBINED_BATTLE,
+			COMBINED_BATTLE_AIR,
+			COMBINED_BATTLE_MIDNIGHT,
+			COMBINED_BATTLE_RESULT
+		}
+
+		/// <summary>
+		/// all apis
+		/// </summary>
+		private static readonly Dictionary<APIType, string> apis = new Dictionary<APIType, string> {
+			{ APIType.PORT,                     "/kcsapi/api_port/port"                          },
+            { APIType.SHIP2,                    "/kcsapi/api_get_member/ship2"                   },
+            { APIType.SHIP3,                    "/kcsapi/api_get_member/ship3"                   },
+            { APIType.KDOCK,                    "/kcsapi/api_get_member/kdock"                   },
+            { APIType.CHANGE,                   "/kcsapi/api_req_hensei/change"                  },
+            { APIType.CREATESHIP,               "/kcsapi/api_req_kousyou/createship"             },
+            { APIType.GETSHIP,                  "/kcsapi/api_req_kousyou/getship"                },
+            { APIType.CREATEITEM,               "/kcsapi/api_req_kousyou/createitem"             },
+            { APIType.START,                    "/kcsapi/api_req_map/start"                      },
+            { APIType.NEXT,                     "/kcsapi/api_req_map/next"                       },
+            { APIType.BATTLE,                   "/kcsapi/api_req_sortie/battle"                  },
+            { APIType.BATTLE_MIDNIGHT,          "/kcsapi/api_req_battle_midnight/battle"         },
+            { APIType.BATTLE_SP_MIDNIGHT,       "/kcsapi/api_req_battle_midnight/sp_midnight"    },
+            { APIType.BATTLE_NIGHT_TO_DAY,      "/kcsapi/api_req_sortie/night_to_day"            },
+            { APIType.BATTLERESULT,             "/kcsapi/api_req_sortie/battleresult"            },
+            { APIType.PRACTICE_BATTLE,          "/kcsapi/api_req_practice/battle"                },
+            { APIType.PRACTICE_BATTLERESULT,    "/kcsapi/api_req_practice/battle_result"         },
+            { APIType.COMBINED_BATTLE,          "/kcsapi/api_req_combined_battle/battle"         },
+            { APIType.COMBINED_BATTLE_AIR,      "/kcsapi/api_req_combined_battle/airbattle"      },
+            { APIType.COMBINED_BATTLE_MIDNIGHT, "/kcsapi/api_req_combined_battle/midnight_battle"},
+            { APIType.COMBINED_BATTLE_RESULT,   "/kcsapi/api_req_combined_battle/battleresult"   }
+		};
+
+		/// <summary>
+		/// read the after-session, determinate whether it will send to kancolle-db.net
+		/// </summary>
+		/// <param name="oSession"></param>
+		public static void ExecuteSession( Session oSession ) {
+
+			if ( !Utility.Configuration.Config.Connection.SendDataToKancolleDB ||
+				Utility.Configuration.Config.Connection.SendKancolleDBApis == 0 ||
+				string.IsNullOrEmpty( Utility.Configuration.Config.Connection.SendKancolleOAuth ) ) {
+
+				return;
+			}
+
+			// find the url in dict.
+			string url = oSession.PathAndQuery;
+			uint apiMask = Utility.Configuration.Config.Connection.SendKancolleDBApis;
+
+			foreach ( var kv in apis ) {
+				if ( url == kv.Value ) {
+
+					// if we allow to post this api.
+					if ( ( ( 1 << (int)kv.Key ) & apiMask ) > 0 ) {
+
+						PostToServer( oSession );
+						return;
+
+					}
+				}
+			}
+
+		}
+
+		private static Regex RequestRegex = new Regex( @"&api(_|%5F)token=[0-9a-f]+|api(_|%5F)token=[0-9a-f]+&?", RegexOptions.Compiled );
+
+		private static void PostToServer( Session oSession ) {
+
+			string oauth = Utility.Configuration.Config.Connection.SendKancolleOAuth;
+			string url = oSession.fullUrl;
+			string request = oSession.GetRequestBodyAsString();
+			string response = oSession.GetResponseBodyAsString().Replace( "svdata=", "" );
+
+			request = RequestRegex.Replace( request, "" );
+
+			try {
+
+				var req = WebRequest.Create( "http://api.kancolle-db.net/2/" );
+				req.Method = "POST";
+				req.ContentType = "application/x-www-form-urlencoded";
+
+				string body =
+					"token=" + HttpUtility.UrlEncode( oauth ) + "&" +
+					"agent=&" +
+					"url=" + HttpUtility.UrlEncode( url ) + "&" +
+					"requestbody=" + HttpUtility.UrlEncode( request ) + "&" +
+					"responsebody=" + HttpUtility.UrlEncode( response );
+				byte[] data = Encoding.ASCII.GetBytes( body );
+				req.ContentLength = data.Length;
+
+				using ( var reqStream = req.GetRequestStream() ) {
+					reqStream.Write( data, 0, data.Length );
+					reqStream.Flush();
+				}
+
+				using ( var resp = (HttpWebResponse)req.GetResponse() ) {
+					using ( var respReader = new StreamReader(resp.GetResponseStream()) )
+					using ( var output = new StreamWriter( @"kancolle-db.log", true, Encoding.UTF8 ) ) {
+
+						output.WriteLine( "[{0}] - {1}: {2}", DateTime.Now, resp.StatusCode, respReader.ReadToEnd() );
+
+					}
+				}
+
+			} catch ( Exception ex ) {
+
+				Utility.ErrorReporter.SendErrorReport( ex, "kancolle-db.netの送信中にエラーが発生しました。" );
+			}
+
+		}
+
+	}
+}

--- a/ElectronicObserver/Observer/APIObserver.cs
+++ b/ElectronicObserver/Observer/APIObserver.cs
@@ -38,6 +38,7 @@ namespace ElectronicObserver.Observer {
 		public event ProxyStartedEventHandler ProxyStarted = delegate { };
 
 		private Control UIControl;
+		private APIKancolleDB DBSender;
 
 		private APIObserver() {
 
@@ -100,6 +101,8 @@ namespace ElectronicObserver.Observer {
 
 
 			ServerAddress = null;
+
+			DBSender = new APIKancolleDB();
 
 			Fiddler.FiddlerApplication.BeforeRequest += FiddlerApplication_BeforeRequest;
 			Fiddler.FiddlerApplication.BeforeResponse += FiddlerApplication_BeforeResponse;
@@ -250,7 +253,7 @@ namespace ElectronicObserver.Observer {
 
 				// kancolle-db.netに送信する
 				if ( Utility.Configuration.Config.Connection.SendDataToKancolleDB ) {
-					Task.Run( (Action)( () => APIKancolleDB.ExecuteSession( oSession ) ) );
+					Task.Run( (Action)( () => DBSender.ExecuteSession( oSession ) ) );
 				}
 
 			}

--- a/ElectronicObserver/Observer/APIObserver.cs
+++ b/ElectronicObserver/Observer/APIObserver.cs
@@ -249,7 +249,9 @@ namespace ElectronicObserver.Observer {
 				UIControl.BeginInvoke( (Action)( () => { LoadResponse( url, body ); } ) );
 
 				// kancolle-db.netに送信する
-				Task.Run( (Action)( () => APIKancolleDB.ExecuteSession( oSession ) ) );
+				if ( Utility.Configuration.Config.Connection.SendDataToKancolleDB ) {
+					Task.Run( (Action)( () => APIKancolleDB.ExecuteSession( oSession ) ) );
+				}
 
 			}
 

--- a/ElectronicObserver/Observer/APIObserver.cs
+++ b/ElectronicObserver/Observer/APIObserver.cs
@@ -248,6 +248,9 @@ namespace ElectronicObserver.Observer {
 				string body = oSession.GetResponseBodyAsString();
 				UIControl.BeginInvoke( (Action)( () => { LoadResponse( url, body ); } ) );
 
+				// kancolle-db.netに送信する
+				Task.Run( (Action)( () => APIKancolleDB.ExecuteSession( oSession ) ) );
+
 			}
 
 

--- a/ElectronicObserver/Utility/Configuration.cs
+++ b/ElectronicObserver/Utility/Configuration.cs
@@ -110,6 +110,22 @@ namespace ElectronicObserver.Utility {
 				/// </summary>
 				public string UpstreamProxyAddress { get; set; }
 
+				/// <summary>
+				/// kancolle-db.netに送信する
+				/// </summary>
+				public bool SendDataToKancolleDB { get; set; }
+
+				/// <summary>
+				/// kancolle-db.netのOAuth認証
+				/// </summary>
+				public string SendKancolleOAuth { get; set; }
+
+				/// <summary>
+				/// APIがに送信されます
+				/// 21 apis which take 21 bits.
+				/// </summary>
+				public uint SendKancolleDBApis { get; set; }
+
 				public ConfigConnection() {
 
 					Port = 40620;
@@ -125,6 +141,9 @@ namespace ElectronicObserver.Utility {
 					UseUpstreamProxy = false;
 					UpstreamProxyPort = 0;
 					UpstreamProxyAddress = "127.0.0.1";
+					SendDataToKancolleDB = false;
+					SendKancolleOAuth = "";
+					SendKancolleDBApis = 0x1FFFFF;
 				}
 
 			}

--- a/ElectronicObserver/Window/Dialog/DialogConfiguration.Designer.cs
+++ b/ElectronicObserver/Window/Dialog/DialogConfiguration.Designer.cs
@@ -26,6 +26,10 @@
 			this.components = new System.ComponentModel.Container();
 			this.tabControl1 = new System.Windows.Forms.TabControl();
 			this.tabPage1 = new System.Windows.Forms.TabPage();
+			this.checkedListBoxKdb = new System.Windows.Forms.CheckedListBox();
+			this.textBoxKdbToken = new System.Windows.Forms.TextBox();
+			this.labelKdb = new System.Windows.Forms.Label();
+			this.checkBoxKdb = new System.Windows.Forms.CheckBox();
 			this.Connection_UpstreamProxyPort = new System.Windows.Forms.NumericUpDown();
 			this.Connection_UseUpstreamProxy = new System.Windows.Forms.CheckBox();
 			this.Connection_RegisterAsSystemProxy = new System.Windows.Forms.CheckBox();
@@ -196,6 +200,10 @@
 			// 
 			// tabPage1
 			// 
+			this.tabPage1.Controls.Add(this.checkedListBoxKdb);
+			this.tabPage1.Controls.Add(this.textBoxKdbToken);
+			this.tabPage1.Controls.Add(this.labelKdb);
+			this.tabPage1.Controls.Add(this.checkBoxKdb);
 			this.tabPage1.Controls.Add(this.Connection_UpstreamProxyPort);
 			this.tabPage1.Controls.Add(this.Connection_UseUpstreamProxy);
 			this.tabPage1.Controls.Add(this.Connection_RegisterAsSystemProxy);
@@ -212,6 +220,40 @@
 			this.tabPage1.TabIndex = 0;
 			this.tabPage1.Text = "通信";
 			this.tabPage1.UseVisualStyleBackColor = true;
+			// 
+			// checkedListBoxKdb
+			// 
+			this.checkedListBoxKdb.FormattingEnabled = true;
+			this.checkedListBoxKdb.Location = new System.Drawing.Point(240, 183);
+			this.checkedListBoxKdb.Name = "checkedListBoxKdb";
+			this.checkedListBoxKdb.Size = new System.Drawing.Size(208, 59);
+			this.checkedListBoxKdb.TabIndex = 12;
+			// 
+			// textBoxKdbToken
+			// 
+			this.textBoxKdbToken.Location = new System.Drawing.Point(87, 226);
+			this.textBoxKdbToken.Name = "textBoxKdbToken";
+			this.textBoxKdbToken.Size = new System.Drawing.Size(144, 20);
+			this.textBoxKdbToken.TabIndex = 11;
+			// 
+			// labelKdb
+			// 
+			this.labelKdb.AutoSize = true;
+			this.labelKdb.Location = new System.Drawing.Point(8, 229);
+			this.labelKdb.Name = "labelKdb";
+			this.labelKdb.Size = new System.Drawing.Size(73, 13);
+			this.labelKdb.TabIndex = 10;
+			this.labelKdb.Text = "OAuth認証：";
+			// 
+			// checkBoxKdb
+			// 
+			this.checkBoxKdb.AutoSize = true;
+			this.checkBoxKdb.Location = new System.Drawing.Point(6, 208);
+			this.checkBoxKdb.Name = "checkBoxKdb";
+			this.checkBoxKdb.Size = new System.Drawing.Size(126, 17);
+			this.checkBoxKdb.TabIndex = 9;
+			this.checkBoxKdb.Text = "kancolle-db.netに送信する";
+			this.checkBoxKdb.UseVisualStyleBackColor = true;
 			// 
 			// Connection_UpstreamProxyPort
 			// 
@@ -1615,6 +1657,10 @@
 
 		private System.Windows.Forms.TabControl tabControl1;
 		private System.Windows.Forms.TabPage tabPage1;
+		private System.Windows.Forms.CheckedListBox checkedListBoxKdb;
+		private System.Windows.Forms.TextBox textBoxKdbToken;
+		private System.Windows.Forms.Label labelKdb;
+		private System.Windows.Forms.CheckBox checkBoxKdb;
 		private System.Windows.Forms.Label label4;
 		private System.Windows.Forms.Panel Connection_PanelSaveData;
 		private System.Windows.Forms.ToolTip ToolTipInfo;

--- a/ElectronicObserver/Window/Dialog/DialogConfiguration.cs
+++ b/ElectronicObserver/Window/Dialog/DialogConfiguration.cs
@@ -112,6 +112,16 @@ namespace ElectronicObserver.Window.Dialog {
 
 			this.Icon = ResourceManager.ImageToIcon( ResourceManager.Instance.Icons.Images[(int)ResourceManager.IconContent.FormConfiguration] );
 
+			checkedListBoxKdb.Items.AddRange( Enum.GetNames( typeof( APIKancolleDB.APIType ) ) );
+			// kancolle-db settings
+			{
+				uint apiMask = Utility.Configuration.Config.Connection.SendKancolleDBApis;
+
+				for ( int i = 0; i < checkedListBoxKdb.Items.Count; i++ ) {
+					checkedListBoxKdb.SetItemChecked( i, ( ( ( 1 << i ) & apiMask ) > 0 ) );
+				}
+			}
+
 		}
 
 		private void DialogConfiguration_FormClosed( object sender, FormClosedEventArgs e ) {
@@ -268,6 +278,8 @@ namespace ElectronicObserver.Window.Dialog {
 			Connection_RegisterAsSystemProxy.Checked = config.Connection.RegisterAsSystemProxy;
 			Connection_UseUpstreamProxy.Checked = config.Connection.UseUpstreamProxy;
 			Connection_UpstreamProxyPort.Value = config.Connection.UpstreamProxyPort;
+			checkBoxKdb.Checked = config.Connection.SendDataToKancolleDB;
+			textBoxKdbToken.Text = config.Connection.SendKancolleOAuth;
 
 			//[UI]
 			UI_MainFont.Font = config.UI.MainFont.FontData;
@@ -399,6 +411,24 @@ namespace ElectronicObserver.Window.Dialog {
 				if ( changed ) {
 					APIObserver.Instance.Stop();
 					APIObserver.Instance.Start( config.Connection.Port, this );
+				}
+
+				// kancolle-db settings
+				{
+					config.Connection.SendDataToKancolleDB = checkBoxKdb.Checked;
+					config.Connection.SendKancolleOAuth = textBoxKdbToken.Text;
+
+					uint apiMask = 0;
+					for ( int i = checkedListBoxKdb.Items.Count - 1; i >= 0; i-- ) {
+
+						apiMask <<= 1;
+
+						if ( checkedListBoxKdb.GetItemChecked( i ) ) {
+							apiMask |= 1;
+						}
+					}
+
+					config.Connection.SendKancolleDBApis = apiMask;
 				}
 			}
 


### PR DESCRIPTION
ユーザーはkancolle-db.netに貢献したい場合。
この機能を実現することができます。

デフォルトではオフになって、ユーザーが設定を開くことができます。
アクセスキーを入力し、通信が（api_tokenが除去されている）kancolle-db.netに送信することができる。

さらに詳しい情報は[kancolle-db.net](http://kancolle-db.net)見つけることができます。

この機能を追加することができた場合は非常に感謝されます。