### PR TITLE
ResourceRecordの検索時に、検索日時よりも１つ古いレコードを返却する問題を修正

### DIFF
--- a/ElectronicObserver/Resource/Record/ResourceRecord.cs
+++ b/ElectronicObserver/Resource/Record/ResourceRecord.cs
@@ -189,9 +189,14 @@ namespace ElectronicObserver.Resource.Record {
 
 			int i;
 			for ( i = Record.Count - 1; i >= 0; i-- ) {
-				if ( Record[i].Date < target )
+				if ( Record[i].Date < target ) {
+					i++;
 					break;
+				}
 			}
+			// Record内の全ての記録がtarget以降だった
+			if ( i < 0 )
+				i = 0;
 
 			if ( 0 <= i && i < Record.Count ) {
 				return Record[i];


### PR DESCRIPTION
戦果計算でResourceRecordを検索するとき、指定した検索日時よりも１つ古いレコードを返却する問題を修正しました。
