### PR TITLE
艦船図鑑の受信艦船数70隻への拡張に対応

### DIFF
--- a/ElectronicObserver/Window/FormInformation.cs
+++ b/ElectronicObserver/Window/FormInformation.cs
@@ -121,12 +121,13 @@ namespace ElectronicObserver.Window {
 			StringBuilder sb = new StringBuilder();
 
 			if ( data.api_list != null ) {
-				const int bound = 50;
-				int startIndex = ( ( (int)data.api_list[0].api_index_no - 1 ) / bound ) * bound + 1;
-				bool[] flags = Enumerable.Repeat<bool>( false, bound ).ToArray();
 
 				if ( data.api_list[0].api_yomi() ) {
 					//艦娘図鑑
+					const int bound = 70;		// 図鑑1ページあたりの艦船数
+					int startIndex = ( ( (int)data.api_list[0].api_index_no - 1 ) / bound ) * bound + 1;
+					bool[] flags = Enumerable.Repeat<bool>( false, bound ).ToArray();
+
 					sb.AppendLine( "[中破絵未回収]" );
 
 					foreach ( dynamic elem in data.api_list ) {
@@ -154,6 +155,10 @@ namespace ElectronicObserver.Window {
 
 				} else {
 					//装備図鑑
+					const int bound = 50;		// 図鑑1ページあたりの装備数
+					int startIndex = ( ( (int)data.api_list[0].api_index_no - 1 ) / bound ) * bound + 1;
+					bool[] flags = Enumerable.Repeat<bool>( false, bound ).ToArray();
+
 					foreach ( dynamic elem in data.api_list ) {
 
 						flags[(int)elem.api_index_no - startIndex] = true;


### PR DESCRIPTION
2015/5/29のアップデートで、艦船図鑑のページ選択時に受信する艦船が50隻から70隻に拡張されたため対応しました。