### PR TITLE
あ号作戦の進捗表示の詳細を、進捗の悪い要素順にしてみた

### DIFF
--- a/ElectronicObserver/Data/Quest/ProgressAGo.cs
+++ b/ElectronicObserver/Data/Quest/ProgressAGo.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace ElectronicObserver.Data.Quest {
+	using DSPair = KeyValuePair<double, string>;
 
 	/// <summary>
 	/// 任務「あ号作戦」の進捗を管理します。
@@ -209,14 +210,13 @@ namespace ElectronicObserver.Data.Quest {
 
 
 		public override string ToString() {
-			return string.Format( "{0:p1} (出撃 {1}/{2}, S勝利 {3}/{4}, ボス {5}/{6}, ボス勝利 {7}/{8})",
-				ProgressPercentage,
-				sortieCount, sortieMax,
-				sWinCount, sWinMax,
-				bossCount, bossMax,
-				bossWinCount, bossWinMax );
+			var list = new List<DSPair>();
+			list.Add( new DSPair( Math.Min((double)sortieCount / sortieMax, 1.0 ), string.Format( "出撃 {0}/{1}", sortieCount, sortieMax ) ) );
+			list.Add( new DSPair( Math.Min((double)sWinCount / sWinMax, 1.0 ), string.Format( "S勝利 {0}/{1}", sWinCount, sWinMax ) ) );
+			list.Add( new DSPair( Math.Min((double)bossCount / bossMax, 1.0 ), string.Format( "ボス {0}/{1}", bossCount, bossMax ) ) );
+			list.Add( new DSPair( Math.Min((double)bossWinCount / bossWinMax, 1.0 ), string.Format( "ボス勝利 {0}/{1}", bossWinCount, bossWinMax ) ) );
+			return string.Format( "{0:p1} ({1})", ProgressPercentage, string.Join( ", ", list.OrderBy( elem => elem.Key ).Select( elem => elem.Value ) ) );
 		}
-
 	}
 
 }


### PR DESCRIPTION
進捗欄に対してあ号の表示内容が大きすぎ、未消化の部分が「...」となってしまって後は何をすればいいのかが一目でわからない！ という問題があるので、進捗が悪い順に表示するようにしてみました。
よろしければ取り込んでくださいませ。