### PR TITLE
起動時に艦これDBの設定が読み込まれない問題を修正

### DIFF
--- a/ElectronicObserver/Window/FormMain.cs
+++ b/ElectronicObserver/Window/FormMain.cs
@@ -56,13 +56,11 @@ namespace ElectronicObserver.Window {
 
 
 		public FormMain() {
+			Utility.Configuration.Instance.Load();
 			InitializeComponent();
 		}
 
 		private async void FormMain_Load( object sender, EventArgs e ) {
-
-			Utility.Configuration.Instance.Load();
-
 
 			Utility.Logger.Instance.LogAdded += new Utility.LogAddedEventHandler( ( Utility.Logger.LogData data ) => {
 				if ( InvokeRequired ) {


### PR DESCRIPTION
staticフィールドの初期化タイミングの問題(beforefieldinit)により、Configuration.Instance.Load()が動作する前にAPIObserverのコンストラクタが動作していたため、APIKancolleDB用の設定が読み込まれなかった問題を修正しました。
(他のシングルトンオブジェクトへの参照が発生する前にConfiguration.Instance.Load()が動作するように場所を移動しました)

ちなみに自分の環境では、Releaseビルドをデバッグ無しで実行した場合にこの問題が発生します。

追記：参照が発生する前、というか同メソッド内でstaticの初回参照が発生しないように、です。