### PR TITLE
交戦記録

### DIFF
--- a/ElectronicObserver/Window/FormCompass.cs
+++ b/ElectronicObserver/Window/FormCompass.cs
@@ -675,6 +675,7 @@ namespace ElectronicObserver.Window {
 				TextEventDetail.ImageIndex = -1;
 				ToolTipInfo.SetToolTip( TextEventDetail, null );
 				TextEnemyFleetName.Text = data.api_deckname;
+                Utility.Logger.Add(2, string.Format("「{0}」と交戦しました。", TextEnemyFleetName.Text));
 
 			} else {
 
@@ -1010,6 +1011,7 @@ namespace ElectronicObserver.Window {
 				var efrecord = RecordManager.Instance.EnemyFleet[efcurrent.FleetID];
 				if ( efrecord != null ) {
 					TextEnemyFleetName.Text = efrecord.FleetName;
+                    Utility.Logger.Add(2, string.Format("「{0}」と交戦しました。", TextEnemyFleetName.Text));
 				}
 				TextEventDetail.Text = "敵艦隊ID: " + efcurrent.FleetID.ToString( "x8" );
 				ToolTipInfo.SetToolTip( TextEventDetail, null );


### PR DESCRIPTION
4-3 レベリングの時意外防止
For stages such as 4-3 leveling, the player can read the battle logs to see if it's time to retreat or go to next battle. It helps to prevent accident. 
よろしければ mergeしなさい。

台湾人です、変な日本語書いたらごめんなさい