### PR TITLE
情報：フォントの自動変更を抑制する

### DIFF
--- a/ElectronicObserver/Window/FormInformation.cs
+++ b/ElectronicObserver/Window/FormInformation.cs
@@ -58,6 +58,7 @@ namespace ElectronicObserver.Window {
 		void ConfigurationChanged() {
 
 			Font = TextInformation.Font = Utility.Configuration.Config.UI.MainFont;
+			TextInformation.LanguageOption = RichTextBoxLanguageOptions.UIFonts;
 		}
 
 


### PR DESCRIPTION
before|after
---|---
![before](https://cloud.githubusercontent.com/assets/2091529/19319450/df544850-90e7-11e6-82cb-578010eddd87.png)|![after](https://cloud.githubusercontent.com/assets/2091529/19319454/e210baf6-90e7-11e6-83d5-972c6121e6a9.png)
*font changes after non-<br>Japanese characters | *font stays on Meiryo UI<br>(default MainFont)
