### PR TITLE
Browser: Improve User Experience 2

### DIFF
--- a/Browser/FormBrowser.cs
+++ b/Browser/FormBrowser.cs
@@ -244,6 +244,7 @@ namespace Browser {
 		}
 
 		private void CenteringBrowser() {
+			if (SizeAdjuster.Width == 0 || SizeAdjuster.Height == 0) return;
 			int x = Browser.Location.X, y = Browser.Location.Y;
 			bool isScrollable = Configuration.IsScrollable;
 
@@ -317,7 +318,8 @@ namespace Browser {
 		/// 指定した URL のページを開きます。
 		/// </summary>
 		public void Navigate( string url ) {
-			StyleSheetApplied = false;
+			if (url == Configuration.LogInPageURL && !Configuration.AppliesStyleSheet)
+				StyleSheetApplied = false;
 			Browser.Navigate( url );
 		}
 

--- a/Browser/Properties/Resources.resx
+++ b/Browser/Properties/Resources.resx
@@ -120,9 +120,14 @@
   <data name="FrameScript" xml:space="preserve">
     <value>
 try {
-$(document.body).css({visibility:"hidden"});
-$("#flashWrap").css({position:"fixed",left:0,top:0,width:"100%",height:"100%"});
-$("#externalswf").css({visibility:"visible",width:"100%",height:"100%"});
+document.body.style.visibility = "hidden";
+var flashWrap = document.getElementById("flashWrap");
+flashWrap.style.position = "fixed";
+flashWrap.style.left = 0; flashWrap.style.top = 0;
+flashWrap.style.width = "100%"; flashWrap.style.height = "100%";
+var externalswf = document.getElementById("externalswf");
+externalswf.style.visibility = "visible";
+externalswf.style.width = "100%"; externalswf.style.height = "100%";
 }
 catch(e) {
 	alert("フレームCSS適用に失敗しました: "+e);
@@ -131,10 +136,16 @@ catch(e) {
   <data name="PageScript" xml:space="preserve">
     <value>
 try {
-$(document.body).css({visibility:"hidden",overflow:"hidden"});
-$(".dmm-ntgnavi").css({display:"none"});
-$("#area-game").css({position:"fixed",left:0,top:0,width:"100%",height:"100%"});
-$("#game_frame").css({visibility:"visible",width:"100%",height:"100%"});
+document.body.style.visibility = "hidden";
+document.body.style.overflow = "hidden";
+document.getElementsByClassName("dmm-ntgnavi")[0].style.display = "none";
+var area_game = document.getElementById("area-game");
+area_game.style.position = "fixed";
+area_game.style.left = 0; area_game.style.top = 0;
+area_game.style.width = "100%"; area_game.style.height = "100%";
+var game_frame = document.getElementById("game_frame");
+game_frame.style.visibility = "visible";
+game_frame.style.width = "100%"; game_frame.style.height = "100%";
 }
 catch(e) {
 	alert("ページCSS適用に失敗しました: "+e);


### PR DESCRIPTION
This pull request does the following:

1. **Prevent Browser position reset when SizeAdjuster size is 0**  
Some time when 74EO is running in background (like minimized) SizeAdjuster of BrowserHost may return 0, this makes Browser move to incorrect position (while stylesheet applied).

2. **Prevent Browser position & size reset when navigate to login page**  
Only reset position & size it navigate to login page without applying stylesheet (the same as refresh)

3. **Use native JavaScript instead of jQuery for FrameScript & PageScript**  
Prevents error when jQuery library is not loaded while trying to apply stylesheet.

---

As a matter of fact, I found that you can simply remove entire ```private void Browser_DocumentCompleted``` section in ```FormBrowser.cs``` and/or the corespoding line in ```FormBrowser.Designer.cs``` :
```
this.Browser.DocumentCompleted += new System.Windows.Forms.WebBrowserDocumentCompletedEventHandler(this.Browser_DocumentCompleted);
```
By doing this, 74EO won't try to apply stylesheet on DocumentCompleted, but stylesheet still gets a chance to apply as it's called in ```InitialAPIReceived()```.

Or, we can check the url on DocumentCompleted, so we only call ```ApplyStylesheet()``` when necessary. The most simple approach wound be:
```c#
private void Browser_DocumentCompleted( object sender, WebBrowserDocumentCompletedEventArgs e ) {
	if (e.Url.AbsolutePath == Browser.Url.AbsolutePath) {
		ApplyStyleSheet();
		ApplyZoom();
	}
}
```

The down side of those later approaches is: stylesheet will be applied _much later_ comparing to the current one (try to apply on every DocumentComplete). Personally I like it to be applied as early as possible, hence I tried to workaround the problems in the current approach as much as possible with this pull request.
