### PR TITLE
Change method of getting Max hp

### DIFF
--- a/ElectronicObserver/Window/FormBattle.cs
+++ b/ElectronicObserver/Window/FormBattle.cs
@@ -754,7 +754,7 @@ namespace ElectronicObserver.Window {
 			bool isEnemyCombined = ( bd.BattleType & BattleData.BattleTypeFlag.EnemyCombined ) != 0;
 
 			var initialHPs = bd.Initial.InitialHPs;
-			var maxHPs = bd.Initial.MaxHPs;
+			// var maxHPs = bd.Initial.MaxHPs;
 			var resultHPs = bd.ResultHPs;
 			var attackDamages = bd.AttackDamages;
 
@@ -763,7 +763,7 @@ namespace ElectronicObserver.Window {
 				if ( initialHPs[i] != -1 ) {
 					HPBars[i].Value = resultHPs[i];
 					HPBars[i].PrevValue = initialHPs[i];
-					HPBars[i].MaximumValue = Math.Max( maxHPs[i], GetBattleShipMaxHP( bd, i ) );		// todo: 暫定処理 メソッドのコメント参照
+					HPBars[i].MaximumValue =  GetBattleShipMaxHP( bd, i );		// todo: 暫定処理 メソッドのコメント参照
 					HPBars[i].BackColor = SystemColors.Control;
 					HPBars[i].Visible = true;
 				} else {
@@ -905,22 +905,17 @@ namespace ElectronicObserver.Window {
 				HPBars[12 + i].BackColor = Color.Moccasin;
 		}
 
-
 		/// <summary>
 		/// 2016/11/19 現在、連合艦隊夜戦において 最大HP = 現在HP となる不具合が存在するため、
+		/// 2016/11/20 Such error only occered in friend escort fleet, so other fleet will still use the data from returned
 		/// 暫定的にマスターデータから最大HPを取得する
 		/// </summary>
 		private int GetBattleShipMaxHP( BattleData bd, int index ) {
-			if ( index < 6 ) {
-				return bd.Initial.FriendFleet.MembersInstance[index].HPMax;
-			} else if ( index < 12 ) {
-				return bd.Initial.EnemyMembersInstance[index - 6].HPMax;
-			} else if ( index < 18 ) {
-				return bd.Initial.FriendFleetEscort.MembersInstance[index - 12].HPMax;
-			} else if ( index < 24 ) {
-				return bd.Initial.EnemyMembersEscortInstance[index - 18].HPMax;
+			//TODO Don't know if the enemy escort fleet has the same error
+			if ( index >= 12 && index < 18 ) {
+				return bd.Initial.FriendFleetEscort.MembersInstance[index-12].HPMax;
 			}
-			throw new ArgumentException( "Wrong index" );
+			return bd.Initial.MaxHPs[index];
 		}
 
 


### PR DESCRIPTION
Sorry for over-fixing in #90 , it causes a problem that hp bars in practice is not shown correctly.
![qq 20161120111429](https://cloud.githubusercontent.com/assets/8273026/20460068/893bbeb4-af12-11e6-9247-37078d43d008.png)
Now only the friend escort fleet will get max hp from fleet data, please check