### PR TITLE
Prevent Browser Navigate Before Proxy Set (workaround)

### DIFF
--- a/Browser/FormBrowser.cs
+++ b/Browser/FormBrowser.cs
@@ -329,6 +329,7 @@ namespace Browser {
 		public void Navigate( string url ) {
 			if ( url != Configuration.LogInPageURL || !Configuration.AppliesStyleSheet )
 				StyleSheetApplied = false;
+			if (!isProxySet) return;
 			Browser.Navigate( url );
 		}
 
@@ -543,6 +544,8 @@ namespace Browser {
 		}
 
 
+		private bool isProxySet = false;
+
 		public void SetProxy( string proxy ) {
 			ushort port;
 			if ( ushort.TryParse( proxy, out port ) ) {
@@ -550,6 +553,9 @@ namespace Browser {
 			} else {
 				WinInetUtil.SetProxyInProcess( proxy, "local" );
 			}
+			isProxySet = true;
+			if (Browser.Document == null && Configuration.IsEnabled)
+				Navigate(Configuration.LogInPageURL);
 
 			//AddLog( 1, "setproxy:" + proxy );
 		}

--- a/Browser/FormBrowser.cs
+++ b/Browser/FormBrowser.cs
@@ -29,7 +29,7 @@ namespace Browser {
 
 
 		private readonly string StyleClassID = Guid.NewGuid().ToString().Substring( 0, 8 );
-		private readonly string RestoreScript = @"var node = document.getElementById('{0}'); if (node) document.head.removeChild(node);";
+		private readonly string RestoreScript = @"var node = document.getElementById('{0}'); if (node) document.getElementsByTagName('head')[0].removeChild(node);";
 		private bool RestoreStyleSheet = false;
 
 		// FormBrowserHostの通信サーバ

--- a/Browser/Properties/Resources.resx
+++ b/Browser/Properties/Resources.resx
@@ -121,13 +121,12 @@
     <value>
 try {{
 var node = document.getElementById('{0}');
-if (node) document.head.removeChild(node);
-node = document.createElement('style');
-node.id = '{0}';
-node.innerHTML = 'body {{ visibility: hidden; }} \
-#flashWrap {{ position: fixed; left: 0; top: 0; width: 100%; height: 100%; }} \
-#externalswf {{ visibility: visible; width: 100%; height: 100%; }}';
-document.head.appendChild(node);
+if (node) document.getElementsByTagName('head')[0].removeChild(node);
+node = document.createElement('div');
+node.innerHTML = 'F&lt;style id=\'{0}\'>body {{ visibility: hidden; }} \
+#flashWrap {{ position: fixed; left: 0; top: 0; width: 100% !important; height: 100% !important; }} \
+#externalswf {{ visibility: visible; width: 100% !important; height: 100% !important; }}&lt;/style>';
+document.getElementsByTagName('head')[0].appendChild(node.lastChild);
 }}
 catch(e) {{
 	alert("フレームCSS適用に失敗しました: "+e);
@@ -137,16 +136,15 @@ catch(e) {{
     <value>
 try {{
 var node = document.getElementById('{0}');
-if (node) document.head.removeChild(node);
-node = document.createElement('style');
-node.id = '{0}';
-node.innerHTML = 'body {{ visibility: hidden; overflow: hidden; }} \
+if (node) document.getElementsByTagName('head')[0].removeChild(node);
+node = document.createElement('div');
+node.innerHTML = 'P&lt;style id=\'{0}\'>body {{ visibility: hidden; overflow: hidden; }} \
 div #block_background {{ visibility: visible; }} \
-div #alert {{ visibility: visible; overflow: scroll; top: 0 !important; left: 3% !important; width: 90% !important; height: 100%; padding:2%;}} \
+div #alert {{ visibility: visible; overflow: scroll; overflow-x: hidden; top: 3% !important; left: 3% !important; width: 94% !important; height: 94%; padding: 2%; box-sizing: border-box;}} \
 div.dmm-ntgnavi {{ display: none; }} \
 #area-game {{ position: fixed; left: 0; top: 0; width: 100%; height: 100%; }} \
-#game_frame {{ visibility: visible; width: 100%; height: 100%; }}';
-document.head.appendChild(node);
+#game_frame {{ visibility: visible; width: 100% !important; height: 100% !important; }}&lt;/style>';
+document.getElementsByTagName('head')[0].appendChild(node.lastChild);
 }}
 catch(e) {{
 	alert("ページCSS適用に失敗しました: "+e);


### PR DESCRIPTION
I tried to fix #95 but failed to figure out how those async runs work. So I did my best and come up with this workaround  75c3d78 . **This is a workaround, not a fix** so it would be better if you can actually fix it.

---
The new switchable stylesheet breaks on IE8, this commit 457cc18 fixes it (and also includes some tweaks to stylesheet). Although IE8 sounds like history, there's no harm to fix it. I insist you cherry-picking this if you decide not to use my workaround above.