### PR TITLE
Slaughter quest counter for enemy combined fleet

### DIFF
--- a/ElectronicObserver/Data/Quest/QuestProgressManager.cs
+++ b/ElectronicObserver/Data/Quest/QuestProgressManager.cs
@@ -365,12 +365,15 @@ namespace ElectronicObserver.Data.Quest {
 
 			#region Slaughter
 
+			bool isEnemyCombined = false;
 
 			if ( bm.StartsFromDayBattle ) {
+				isEnemyCombined = (bm.BattleDay.BattleType & ElectronicObserver.Data.Battle.BattleData.BattleTypeFlag.EnemyCombined ) != 0;
 				if ( bm.BattleNight != null ) hps = bm.BattleNight.ResultHPs;
 				else hps = bm.BattleDay.ResultHPs;
 
 			} else {
+				isEnemyCombined = (bm.BattleNight.BattleType & ElectronicObserver.Data.Battle.BattleData.BattleTypeFlag.EnemyCombined ) != 0;
 				if ( bm.BattleDay != null ) hps = bm.BattleDay.ResultHPs;
 				else hps = bm.BattleNight.ResultHPs;
 			}
@@ -388,6 +391,14 @@ namespace ElectronicObserver.Data.Quest {
 
 					foreach ( var p in slaughterList )
 						p.Increment( ship.ShipType );
+				}
+
+				if(isEnemyCombined && hps[i + 18] <= 0) {
+					var ship = bm.BattleDay != null ? bm.BattleDay.Initial.EnemyMembersEscortInstance[i] : bm.BattleNight.Initial.EnemyMembersEscortInstance[i];
+					if ( ship == null ) continue;
+
+					foreach ( var p in slaughterList )
+						p.Increment( ship.ShipType );					
 				}
 
 			}


### PR DESCRIPTION
Killing enemy in enemy's escort fleet will also increase the progress of slaughter quest like ろ号作戦, so I make it possible to count the number in QuestProgressManager.

My log for confirmation.
[KCAPI_E5.zip](https://github.com/andanteyk/ElectronicObserver/files/610586/KCAPI_E5.zip)
Key log is the `each_battle.json` at last.