### PR TITLE
Prevent Duplicate Rows in Equipment List

### DIFF
--- a/ElectronicObserver/Window/Dialog/DialogEquipmentList.cs
+++ b/ElectronicObserver/Window/Dialog/DialogEquipmentList.cs
@@ -383,17 +383,21 @@ namespace ElectronicObserver.Window.Dialog {
 
 			foreach ( var c in countlist.Values ) {
 
-				if ( c.equippedShips.Count() == 0 ) {
-					c.equippedShips.Add( "" );
-				}
+				var row = new DataGridViewRow();
+				row.CreateCells( DetailView );
 
-				foreach ( var s in c.equippedShips ) {
-
-					var row = new DataGridViewRow();
-					row.CreateCells( DetailView );
-					row.SetValues( c.level, c.aircraftLevel, c.countAll, c.countRemain, s );
-					rows.Add( row );
+				string equippedShips = "";
+				if ( c.equippedShips.Count() != 0 ) {
+					equippedShips = String.Join( "\r\n" , c.equippedShips );
 				}
+				row.SetValues( c.level, c.aircraftLevel, c.countAll, c.countRemain, equippedShips );
+				if ( c.equippedShips.Count() > 1 ) {
+					row.DefaultCellStyle.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+					row.DefaultCellStyle.Alignment = DataGridViewContentAlignment.TopRight;
+					row.Cells[4].Style.Alignment   = DataGridViewContentAlignment.TopLeft;
+					row.DefaultCellStyle.Padding = new Padding( 0, 1, 0, 1 );
+				}
+				rows.Add( row );
 
 			}
 


### PR DESCRIPTION
It seems I run into the same problem of #69 
![image](https://cloud.githubusercontent.com/assets/2091529/21221983/feb6093e-c302-11e6-84e5-8c3d1574a7a0.png)

After reading the code, it seems the original `DataView` approach (having multiple rows for every ship with that equipment) is causing the problem: when calling `DetailView.Sort`, the rows would be break apart. **Even if I fix the initial sorting, the list would break again once user sort it manually.**

I don't know how to fix that, but I came up with another approach - having only one row. This way there's no chance of breaking apart as there's only one single row. 

You're more than welcome to work on your own fix if you don't like my approach. In fact I myself don't really like my code as it doesn't provide the exactly same appreance as before. I tried my best to add padding to it but still can't find a way to make "line height" the same.