### PR TITLE
戦闘詳細：画面外に表示される不具合を修正

### DIFF
--- a/ElectronicObserver/Window/Dialog/DialogBattleDetail.cs
+++ b/ElectronicObserver/Window/Dialog/DialogBattleDetail.cs
@@ -37,7 +37,21 @@ namespace ElectronicObserver.Window.Dialog {
 				Math.Min( TextBattleDetail.Location.X * 2 + TextBattleDetail.Width + TextBattleDetail.Margin.Horizontal, 800 ),
 				Math.Min( TextBattleDetail.Location.Y * 2 + TextBattleDetail.Height + TextBattleDetail.Margin.Vertical, 600 ) );
 
-			//Location -= new Size( Width / 2, Height / 2 );
+ 			var workingScreen = Screen.GetWorkingArea( Location );
+			var dialogRectangle = new Rectangle( Left, Top, Right, Bottom );
+
+			if ( !workingScreen.Contains( dialogRectangle ) ) {
+
+				if ( Right > workingScreen.Right && Bottom > workingScreen.Bottom ) {
+					Location = new Point( workingScreen.Right - Width, workingScreen.Bottom - Height );
+				} else if ( Right > workingScreen.Right ) {
+					Location = new Point( workingScreen.Right - Width, Top );
+				} else if ( Bottom > workingScreen.Bottom ) {
+					Location = new Point( Left, workingScreen.Bottom - Height );
+				} else {
+					return; // モニターを Location で指定してあるので例外はないはず。
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
戦闘詳細の一部が特定のレイアウト環境で画面外に表示される不具合を修正しました。
具体的には戦闘ウィンドウあるいは右クリックがモニター画面の右端や下端の付近にあるときに発生します。
これは表示位置が `FormBattle.cs` （1131行） でコンテキストメニューの座標で指定されているためです。

			dialog.Location = RightClickMenu.Location;

上記の解決のため `DialogBattleDetail.cs` にて実際のダイアログのサイズを取得したのち表示位置の再指定を行うよう調整しています。