### PR TITLE
ブラウザ：DMMによるページ更新ダイアログの非表示を可能に

### DIFF
--- a/Browser/FormBrowser.cs
+++ b/Browser/FormBrowser.cs
@@ -224,6 +224,7 @@ namespace Browser {
 			//ロード直後の適用ではレイアウトがなぜか崩れるのでこのタイミングでも適用
 			ApplyStyleSheet();
 			ApplyZoom();
+			DestroyDMMreloadDialog();
 
 			//起動直後はまだ音声が鳴っていないのでミュートできないため、この時点で有効化
 			SetVolumeState();
@@ -278,6 +279,7 @@ namespace Browser {
 			ApplyStyleSheet();
 
 			ApplyZoom();
+			DestroyDMMreloadDialog();
 		}
 
 		/// <summary>
@@ -319,6 +321,32 @@ namespace Browser {
 
 				BrowserHost.AsyncRemoteRun( () =>
 					BrowserHost.Proxy.SendErrorReport( ex.ToString(), "スタイルシートの適用に失敗しました。" ) );
+			}
+
+		}
+		
+		/// <summary>
+		/// DMMによるページ更新ダイアログを非表示にします。
+		/// </summary>
+		public void DestroyDMMreloadDialog() {
+
+			if ( !Configuration.IsDMMreloadDialogDestroyable  )
+				return;
+
+			try {
+
+				var document = Browser.Document;
+				if ( document == null ) return;
+
+				var swf = getFrameElementById( document, "externalswf" );
+				if ( swf == null ) return;
+
+				document.InvokeScript( "eval", new object[] { Properties.Resources.DMMScript } );
+				
+			} catch ( Exception ex ) {
+
+				BrowserHost.AsyncRemoteRun( () =>
+					BrowserHost.Proxy.SendErrorReport( ex.ToString(), "DMMによるページ更新ダイアログの非表示に失敗しました。" ) );
 			}
 
 		}

--- a/Browser/Properties/Resources.Designer.cs
+++ b/Browser/Properties/Resources.Designer.cs
@@ -98,5 +98,12 @@ namespace Browser.Properties {
                 return ResourceManager.GetString("PageScript", resourceCulture);
             }
         }
+		
+        internal static string DMMScript {
+            get {
+                return ResourceManager.GetString("DMMScript", resourceCulture);
+            }
+        }
+		
     }
 }

--- a/Browser/Properties/Resources.resx
+++ b/Browser/Properties/Resources.resx
@@ -150,4 +150,13 @@ catch(e) {{
 	alert("ページCSS適用に失敗しました: "+e);
 }}</value>
   </data>
+  <data name="DMMScript" xml:space="preserve">
+    <value>
+try {
+	if ( DMM.netgame.reloadDialog ) DMM.netgame.reloadDialog = function (){};
+}
+catch(e) {
+	alert("DMMによるページ更新ダイアログの非表示に失敗しました: "+e);
+}</value>
+  </data>
 </root>

--- a/BrowserLib/IBrowser.cs
+++ b/BrowserLib/IBrowser.cs
@@ -38,6 +38,9 @@ namespace BrowserLib {
 
 		[OperationContract]
 		void ApplyStyleSheet();
+		
+		[OperationContract]
+		void DestroyDMMreloadDialog();
 
 		[OperationContract]
 		void CloseBrowser();

--- a/BrowserLib/IBrowserHost.cs
+++ b/BrowserLib/IBrowserHost.cs
@@ -121,6 +121,12 @@ namespace BrowserLib {
 		/// </summary>
 		[DataMember]
 		public bool AppliesStyleSheet { get; set; }
+		
+		/// <summary>
+		/// DMMによるページ更新ダイアログを表示するか
+		/// </summary>
+		[DataMember]
+		public bool IsDMMreloadDialogDestroyable { get; set; }
 
 		/// <summary>
 		/// ツールメニューの配置

--- a/ElectronicObserver/Utility/Configuration.cs
+++ b/ElectronicObserver/Utility/Configuration.cs
@@ -812,6 +812,11 @@ namespace ElectronicObserver.Utility {
 				/// スタイルシートを適用するか
 				/// </summary>
 				public bool AppliesStyleSheet { get; set; }
+				
+				/// <summary>
+				/// DMMによるページ更新ダイアログを非表示にするか
+				/// </summary>
+				public bool IsDMMreloadDialogDestroyable { get; set; }
 
 				/// <summary>
 				/// ツールメニューの配置

--- a/ElectronicObserver/Window/Dialog/DialogConfiguration.Designer.cs
+++ b/ElectronicObserver/Window/Dialog/DialogConfiguration.Designer.cs
@@ -146,6 +146,7 @@
 			this.FormBattle_HideDuringBattle = new System.Windows.Forms.CheckBox();
 			this.FormBattle_IsScrollable = new System.Windows.Forms.CheckBox();
 			this.tabPage12 = new System.Windows.Forms.TabPage();
+			this.FormBrowser_IsDMMreloadDialogDestroyable = new System.Windows.Forms.CheckBox();
 			this.FormBrowser_ToolMenuDockStyle = new System.Windows.Forms.ComboBox();
 			this.label30 = new System.Windows.Forms.Label();
 			this.FormBrowser_ZoomFit = new System.Windows.Forms.CheckBox();
@@ -1678,6 +1679,7 @@
 			// 
 			// tabPage12
 			// 
+			this.tabPage12.Controls.Add(this.FormBrowser_IsDMMreloadDialogDestroyable);
 			this.tabPage12.Controls.Add(this.FormBrowser_ToolMenuDockStyle);
 			this.tabPage12.Controls.Add(this.label30);
 			this.tabPage12.Controls.Add(this.FormBrowser_ZoomFit);
@@ -1697,6 +1699,17 @@
 			this.tabPage12.TabIndex = 3;
 			this.tabPage12.Text = "ブラウザ";
 			this.tabPage12.UseVisualStyleBackColor = true;
+			// 
+			// FormBrowser_IsDMMreloadDialogDestroyable
+			// 
+			this.FormBrowser_IsDMMreloadDialogDestroyable.AutoSize = true;
+			this.FormBrowser_IsDMMreloadDialogDestroyable.Location = new System.Drawing.Point(282, 90);
+			this.FormBrowser_IsDMMreloadDialogDestroyable.Name = "FormBrowser_IsDMMreloadDialogDestroyable";
+			this.FormBrowser_IsDMMreloadDialogDestroyable.Size = new System.Drawing.Size(245, 19);
+			this.FormBrowser_IsDMMreloadDialogDestroyable.TabIndex = 12;
+			this.FormBrowser_IsDMMreloadDialogDestroyable.Text = "DMMによるページ更新ダイアログを非表示にする";
+			this.ToolTipInfo.SetToolTip(this.FormBrowser_IsDMMreloadDialogDestroyable, "DMMによる「エラーが発生したため、ページ更新します。」の確認ダイアログを表示されないようにします。");
+			this.FormBrowser_IsDMMreloadDialogDestroyable.UseVisualStyleBackColor = true;
 			// 
 			// FormBrowser_ToolMenuDockStyle
 			// 
@@ -2821,6 +2834,7 @@
 		private System.Windows.Forms.ComboBox FormHeadquarters_DisplayUseItemID;
 		private System.Windows.Forms.CheckBox FormBattle_HideDuringBattle;
 		private System.Windows.Forms.CheckBox Log_SaveBattleLog;
+		private System.Windows.Forms.CheckBox FormBrowser_IsDMMreloadDialogDestroyable;
 		private System.Windows.Forms.Label label35;
 		private System.Windows.Forms.NumericUpDown FormFleet_FixedShipNameWidth;
 	}

--- a/ElectronicObserver/Window/Dialog/DialogConfiguration.cs
+++ b/ElectronicObserver/Window/Dialog/DialogConfiguration.cs
@@ -403,6 +403,7 @@ namespace ElectronicObserver.Window.Dialog {
 			FormBrowser_ScreenShotPath.Text = config.FormBrowser.ScreenShotPath;
 			FormBrowser_ConfirmAtRefresh.Checked = config.FormBrowser.ConfirmAtRefresh;
 			FormBrowser_AppliesStyleSheet.Checked = config.FormBrowser.AppliesStyleSheet;
+			FormBrowser_IsDMMreloadDialogDestroyable.Checked = config.FormBrowser.IsDMMreloadDialogDestroyable;
 			{
 				Microsoft.Win32.RegistryKey reg = null;
 				try {
@@ -626,6 +627,7 @@ namespace ElectronicObserver.Window.Dialog {
 			config.FormBrowser.ScreenShotPath = FormBrowser_ScreenShotPath.Text;
 			config.FormBrowser.ConfirmAtRefresh = FormBrowser_ConfirmAtRefresh.Checked;
 			config.FormBrowser.AppliesStyleSheet = FormBrowser_AppliesStyleSheet.Checked;
+			config.FormBrowser.IsDMMreloadDialogDestroyable = FormBrowser_IsDMMreloadDialogDestroyable.Checked;
 			config.FormBrowser.FlashQuality = FormBrowser_FlashQuality.Text;
 			config.FormBrowser.FlashWMode = FormBrowser_FlashWMode.Text;
 			if ( FormBrowser_ToolMenuDockStyle.SelectedIndex == 4 ) {

--- a/ElectronicObserver/Window/FormBrowserHost.cs
+++ b/ElectronicObserver/Window/FormBrowserHost.cs
@@ -164,6 +164,13 @@ namespace ElectronicObserver.Window {
 		public void ApplyStyleSheet() {
 			Browser.AsyncRemoteRun( () => Browser.Proxy.ApplyStyleSheet() );
 		}
+		
+		/// <summary>
+		/// DMMによるページ更新ダイアログを非表示にします。
+		/// </summary>
+		public void DestroyDMMreloadDialog() {
+			Browser.AsyncRemoteRun( () => Browser.Proxy.DestroyDMMreloadDialog() );
+		}
 
 
 		/// <summary>
@@ -198,6 +205,7 @@ namespace ElectronicObserver.Window {
 				config.StyleSheet = c.StyleSheet;
 				config.IsScrollable = c.IsScrollable;
 				config.AppliesStyleSheet = c.AppliesStyleSheet;
+				config.IsDMMreloadDialogDestroyable = c.IsDMMreloadDialogDestroyable;
 				config.ToolMenuDockStyle = (int)c.ToolMenuDockStyle;
 				config.IsToolMenuVisible = c.IsToolMenuVisible;
 				config.ConfirmAtRefresh = c.ConfirmAtRefresh;
@@ -219,6 +227,7 @@ namespace ElectronicObserver.Window {
 			c.StyleSheet = config.StyleSheet;
 			c.IsScrollable = config.IsScrollable;
 			c.AppliesStyleSheet = config.AppliesStyleSheet;
+			c.IsDMMreloadDialogDestroyable = config.IsDMMreloadDialogDestroyable;
 			c.ToolMenuDockStyle = (DockStyle)config.ToolMenuDockStyle;
 			c.IsToolMenuVisible = config.IsToolMenuVisible;
 			c.ConfirmAtRefresh = config.ConfirmAtRefresh;


### PR DESCRIPTION
DMMのゲーム画面にて表示されるページ更新ダイアログを表示させない機能を追加しました。
具体的な方法は下記の confirm メソッド を含む function 関数 を上書きすることで実現しています。

        reloadDialog : function() {
            if (confirm("エラーが発生したため、ページ更新します。")) {
                location.reload();
            }
        }

おそらく多重ログインを防止するために組み込んであるのですが誤更新してしまう原因にもなります。
なのでデフォルトとしてではなく設定から任意で機能のオンオフを切り替えができるように設計してあります。
なお参考までに reloadDialog 関連の JavaScript コード を添付しておきます。
[reloadDialog.txt](https://github.com/andanteyk/ElectronicObserver/files/671244/reloadDialog.txt)