### PR TITLE
Add an option to display aircraft level as digits instead of icons

### DIFF
--- a/ElectronicObserver/Utility/Configuration.cs
+++ b/ElectronicObserver/Utility/Configuration.cs
@@ -606,6 +606,11 @@ namespace ElectronicObserver.Utility {
 				public Window.Control.ShipStatusEquipment.LevelVisibilityFlag EquipmentLevelVisibility { get; set; }
 
 				/// <summary>
+				/// 艦載機熟練度を数字で表示フラグ
+				/// </summary>
+				public bool ShowTextAircraftLevel { get; set; }
+
+				/// <summary>
 				/// 制空戦力の計算方法
 				/// </summary>
 				public int AirSuperiorityMethod { get; set; }
@@ -638,6 +643,7 @@ namespace ElectronicObserver.Utility {
 					ShortenHPBar = false;
 					ShowNextExp = true;
 					EquipmentLevelVisibility = Window.Control.ShipStatusEquipment.LevelVisibilityFlag.Both;
+					ShowTextAircraftLevel = false;
 					AirSuperiorityMethod = 1;
 					ShowAnchorageRepairingTimer = true;
 					BlinkAtCompletion = true;

--- a/ElectronicObserver/Window/Control/ShipStatusEquipment.cs
+++ b/ElectronicObserver/Window/Control/ShipStatusEquipment.cs
@@ -283,6 +283,23 @@ namespace ElectronicObserver.Window.Control {
 		}
 
 
+		private bool _showTextAircraftLevel;
+		/// <summary>
+		/// 艦載機熟練度を数字で表示するか
+		/// </summary>
+		[Browsable(true), Category("Behavior"), DefaultValue(false)]
+		[Description("艦載機熟練度の表示モードを指定します。")]
+		public bool ShowTextAircraftLevel
+		{
+			get { return _showTextAircraftLevel; }
+			set
+			{
+				_showTextAircraftLevel = value;
+				PropertyChanged();
+			}
+		}
+
+
 		private int _slotMargin;
 		/// <summary>
 		/// スロット間の空きスペース
@@ -356,6 +373,7 @@ namespace ElectronicObserver.Window.Control {
 			_overlayAircraft = false;
 
 			_levelVisibility = LevelVisibilityFlag.Both;
+			_showTextAircraftLevel = false;
 
 			_slotMargin = 3;
 			_aircraftMargin = 3;
@@ -673,16 +691,19 @@ namespace ElectronicObserver.Window.Control {
 						else
 							levelcol = AircraftLevelColorHigh;
 
-						switch ( slot.AircraftLevel ) {
-							case 1: leveltext = "|"; break;
-							case 2: leveltext = "||"; break;
-							case 3: leveltext = "|||"; break;
-							case 4: leveltext = "/"; break;
-							case 5: leveltext = "//"; break;
-							case 6: leveltext = "///"; break;
-							case 7: leveltext = ">>"; break;
-							default: leveltext = "x"; break;
-						}
+						if (ShowTextAircraftLevel)
+							leveltext = slot.AircraftLevel.ToString();
+						else
+							switch ( slot.AircraftLevel ) {
+								case 1: leveltext = "|"; break;
+								case 2: leveltext = "||"; break;
+								case 3: leveltext = "|||"; break;
+								case 4: leveltext = "/"; break;
+								case 5: leveltext = "//"; break;
+								case 6: leveltext = "///"; break;
+								case 7: leveltext = ">>"; break;
+								default: leveltext = "x"; break;
+							}
 
 						TextRenderer.DrawText( e.Graphics, leveltext, Font, textarea, levelcol, textformatLevel );
 					}

--- a/ElectronicObserver/Window/Dialog/DialogConfiguration.Designer.cs
+++ b/ElectronicObserver/Window/Dialog/DialogConfiguration.Designer.cs
@@ -221,6 +221,7 @@
 			this.PlayTimeTimer = new System.Windows.Forms.Timer(this.components);
 			this.FormFleet_FixedShipNameWidth = new System.Windows.Forms.NumericUpDown();
 			this.label35 = new System.Windows.Forms.Label();
+			this.FormFleet_ShowTextAircraftLevel = new System.Windows.Forms.CheckBox();
 			this.tabControl1.SuspendLayout();
 			this.tabPage1.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.Connection_UpstreamProxyPort)).BeginInit();
@@ -1121,6 +1122,7 @@
 			// 
 			// tabPage8
 			// 
+			this.tabPage8.Controls.Add(this.FormFleet_ShowTextAircraftLevel);
 			this.tabPage8.Controls.Add(this.label35);
 			this.tabPage8.Controls.Add(this.FormFleet_FixedShipNameWidth);
 			this.tabPage8.Controls.Add(this.FormFleet_ShowConditionIcon);
@@ -2533,6 +2535,17 @@
 			this.label35.Size = new System.Drawing.Size(21, 15);
 			this.label35.TabIndex = 8;
 			this.label35.Text = "px";
+			//
+			// FormFleet_ShowTextAircraftLevel
+			//
+			this.FormFleet_ShowTextAircraftLevel.AutoSize = true;
+			this.FormFleet_ShowTextAircraftLevel.Location = new System.Drawing.Point(159, 188);
+			this.FormFleet_ShowTextAircraftLevel.Name = "FormFleet_ShowTextAircraftLevel";
+			this.FormFleet_ShowTextAircraftLevel.Size = new System.Drawing.Size(184, 19);
+			this.FormFleet_ShowTextAircraftLevel.TabIndex = 16;
+			this.FormFleet_ShowTextAircraftLevel.Text = "艦載機熟練度を数字で表示する";
+			this.ToolTipInfo.SetToolTip(this.FormFleet_ShowTextAircraftLevel, "艦載機熟練度を記号（|, || など）でなく数字（1, 2 など）で表示する");
+			this.FormFleet_ShowTextAircraftLevel.UseVisualStyleBackColor = true;
 			// 
 			// DialogConfiguration
 			// 
@@ -2823,5 +2836,6 @@
 		private System.Windows.Forms.CheckBox Log_SaveBattleLog;
 		private System.Windows.Forms.Label label35;
 		private System.Windows.Forms.NumericUpDown FormFleet_FixedShipNameWidth;
+		private System.Windows.Forms.CheckBox FormFleet_ShowTextAircraftLevel;
 	}
 }

--- a/ElectronicObserver/Window/Dialog/DialogConfiguration.cs
+++ b/ElectronicObserver/Window/Dialog/DialogConfiguration.cs
@@ -350,6 +350,7 @@ namespace ElectronicObserver.Window.Dialog {
 			FormFleet_ShortenHPBar.Checked = config.FormFleet.ShortenHPBar;
 			FormFleet_ShowNextExp.Checked = config.FormFleet.ShowNextExp;
 			FormFleet_EquipmentLevelVisibility.SelectedIndex = (int)config.FormFleet.EquipmentLevelVisibility;
+			FormFleet_ShowTextAircraftLevel.Checked = config.FormFleet.ShowTextAircraftLevel;
 			FormFleet_AirSuperiorityMethod.SelectedIndex = config.FormFleet.AirSuperiorityMethod;
 			FormFleet_ShowAnchorageRepairingTimer.Checked = config.FormFleet.ShowAnchorageRepairingTimer;
 			FormFleet_BlinkAtCompletion.Checked = config.FormFleet.BlinkAtCompletion;
@@ -565,6 +566,7 @@ namespace ElectronicObserver.Window.Dialog {
 			config.FormFleet.ShortenHPBar = FormFleet_ShortenHPBar.Checked;
 			config.FormFleet.ShowNextExp = FormFleet_ShowNextExp.Checked;
 			config.FormFleet.EquipmentLevelVisibility = (Window.Control.ShipStatusEquipment.LevelVisibilityFlag)FormFleet_EquipmentLevelVisibility.SelectedIndex;
+			config.FormFleet.ShowTextAircraftLevel = FormFleet_ShowTextAircraftLevel.Checked;
 			config.FormFleet.AirSuperiorityMethod = FormFleet_AirSuperiorityMethod.SelectedIndex;
 			config.FormFleet.ShowAnchorageRepairingTimer = FormFleet_ShowAnchorageRepairingTimer.Checked;
 			config.FormFleet.BlinkAtCompletion = FormFleet_BlinkAtCompletion.Checked;

--- a/ElectronicObserver/Window/FormFleet.cs
+++ b/ElectronicObserver/Window/FormFleet.cs
@@ -1054,6 +1054,7 @@ namespace ElectronicObserver.Window {
 				bool showNext = c.FormFleet.ShowNextExp;
 				bool showConditionIcon = c.FormFleet.ShowConditionIcon;
 				var levelVisibility = c.FormFleet.EquipmentLevelVisibility;
+				bool showTextAircraftLevel = c.FormFleet.ShowTextAircraftLevel;
 				int fixedShipNameWidth = c.FormFleet.FixedShipNameWidth;
 
 				for ( int i = 0; i < ControlMember.Length; i++ ) {
@@ -1071,6 +1072,7 @@ namespace ElectronicObserver.Window {
 					ControlMember[i].Level.TextNext = showNext ? "next:" : null;
 					ControlMember[i].Condition.ImageAlign = showConditionIcon ? ContentAlignment.MiddleLeft : ContentAlignment.MiddleCenter;
 					ControlMember[i].Equipments.LevelVisibility = levelVisibility;
+					ControlMember[i].Equipments.ShowTextAircraftLevel = showTextAircraftLevel;
 					ControlMember[i].ShipResource.BarFuel.ColorMorphing =
 					ControlMember[i].ShipResource.BarAmmo.ColorMorphing = colorMorphing;
 					ControlMember[i].ShipResource.BarFuel.SetBarColorScheme( colorScheme );


### PR DESCRIPTION
This PR adds an option so the user can choose to display aircraft level as digits (1, 2, etc.) instead of icons (|, ||, etc.).

Preview:
![](https://cloud.githubusercontent.com/assets/2557768/22465585/6dab51c8-e7f7-11e6-81a0-fb31d0e65d0d.png)

When aircraft has 改修レベル, two digits will overlap and it is difficult to see them. Probably we should find a better way to display them when they are both present?