### PR TITLE
Ignore FIPS Policy

### DIFF
--- a/ElectronicObserver/App.config
+++ b/ElectronicObserver/App.config
@@ -10,5 +10,6 @@
         <bindingRedirect oldVersion="0.0.0.0-1.2.14.0" newVersion="1.2.14.0" />
       </dependentAssembly>
     </assemblyBinding>
+    <enforceFIPSPolicy enabled="false"/>
   </runtime>
 </configuration>

--- a/ElectronicObserver/Program.cs
+++ b/ElectronicObserver/Program.cs
@@ -1,7 +1,10 @@
 ﻿using ElectronicObserver.Window;
+using ElectronicObserver.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -18,6 +21,28 @@ namespace ElectronicObserver {
 			if ( !mutex.WaitOne( 0, false ) ) {
 				// 多重起動禁止
 				MessageBox.Show( "既に起動しています。\r\n多重起動はできません。", "七四式電子観測儀", MessageBoxButtons.OK, MessageBoxIcon.Error );
+				return;
+			}
+
+			try
+			{
+				MD5.Create();
+			}
+			catch (TargetInvocationException ex)
+			{
+				if (ex.InnerException is InvalidOperationException)
+				{
+					MessageBox.Show(
+						"FIPS 有効の場合、このソフトは実行できません。\nレジストリの " +
+						"HKLM\\System\\CurrentControlSet\\Control\\Lsa\\FIPSAlgorithmPolicy\\Enabled" +
+						" キーの値を 0 に直してください。", "七四式電子観測儀", MessageBoxButtons.OK, MessageBoxIcon.Error);
+				}
+				else
+				{
+					MessageBox.Show("MD5 ハッシュを作成できません。このエラーを報告してください。", 
+						"七四式電子観測儀", MessageBoxButtons.OK, MessageBoxIcon.Error);
+				}
+				ErrorReporter.SendErrorReport(ex.InnerException, "MD5 ハッシュを作成できません。");
 				return;
 			}
 


### PR DESCRIPTION
Recently there have been error reports that look like this
```
エラーレポート [ver. 2.5.4.1] : 2017/03/03 19:23:39
エラー : TargetInvocationException
Exception has been thrown by the target of an invocation.
追加情報 : Responseの受信中にエラーが発生しました。
スタックトレース：
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Security.Cryptography.CryptoConfig.CreateFromName(String name, Object[] args)
   at System.Security.Cryptography.MD5.Create()
   ...
```

The `InnerException` is InvalidOperationException: This implementation is not part of the Windows Platform FIPS validated cryptographic algorithms.

This happens when we attempt to save 敵艦隊編成 and the user's system has FIPS policy turned on. FIPS standard does not allow usage of MD5 thus causing the exception to be thrown. This problem was located by @RadarNyan.

This PR:
* Add a runtime configuration to ignore FIPS mode;
* If MD5 still cannot be used, warn the user.

Ref:
https://blogs.msdn.microsoft.com/shawnfa/2008/03/14/disabling-the-fips-algorithm-check/
http://support.microsoft.com/kb/811833