### PR TITLE
Cast IntPtr to long before casting it to uint

### DIFF
--- a/ElectronicObserver/Window/Integrate/FormIntegrated.cs
+++ b/ElectronicObserver/Window/Integrate/FormIntegrated.cs
@@ -262,7 +262,7 @@ namespace ElectronicObserver.Window.Integrate {
 				StripMenu_Detach.Enabled = true;
 			}
 
-			origStyle = (uint)WinAPI.GetWindowLong( hWnd, WinAPI.GWL_STYLE );
+			origStyle = unchecked((uint)(long)WinAPI.GetWindowLong( hWnd, WinAPI.GWL_STYLE ));
 			origOwner = WinAPI.GetWindowLong( hWnd, WinAPI.GWL_HWNDPARENT );
 
 			// ターゲットが最大化されていたら戻す


### PR DESCRIPTION
On a x64 platform, casting a `IntPtr` directly to `uint` will result in a `System.OverflowException` if the value of that `IntPtr` is more than `0x7FFFFFFF`.

When doing such casting, `IntPtr` is actually first casted to `int` and then casted to `uint` (confirmed by checking IL code generated by compiler). The casting from `IntPtr` to `int` is implemented as
```c#
public unsafe static explicit operator int (IntPtr  value) 
{
    #if WIN32
        return (int)value.m_value;
    #else
        long l = (long)value.m_value;
        return checked((int)l);
    #endif
}
```
Let's say we have a `IntPtr` of value `0xFFFFFFFF`. On a x86 system it will get casted to `-1` as a `int` and when later casted again to `uint`, it gets back to `0xFFFFFFFF` as expected. On a x64 system however, it is actually doing a `checked` casting from `0x00000000FFFFFFFF` to `int` and this will immediately throw the overflow exception.

This PR adds a workaround by casting `IntPtr` to `long` first, which is implemented as
```c#
public unsafe static explicit operator long (IntPtr  value) 
{
    #if WIN32
        return (long)(int)value.m_value;
    #else
        return (long)value.m_value;
    #endif
}
```
After this we do another `unchecked` casting to `uint` to get the final result. On a x86 platform, it will first become `0xFFFFFFFFFFFFFFFF` and later gets truncated back to the expected value. On a x64 platform, the original `IntPtr` is 64-bit so it becomes a `long` of `0x00000000FFFFFFFF` and is later truncated back to the same result.

Note that due to design of `IntPtr`, if you need to test the behavior you need to initialize it as `new IntPtr((void*) 0xFFFFFFFF)`. Otherwise it will throw an overflow exception on x86 (Ref: dotnet/coreclr#4062, dotnet/corefx#7540).

There is also no way to cast `IntPtr` directly to `ulong` (dotnet/coreclr#6855) currently.

This PR should fix errors like this
```
エラーレポート [ver. 2.5.4.1] : 2017/03/11 01:32:48
エラー : OverflowException
算术运算导致溢出。
追加情報 : Error in thread: 算术运算导致溢出。
スタックトレース：
在 System.IntPtr.op_Explicit(IntPtr value)
在 ElectronicObserver.Window.Integrate.FormIntegrate.Attach(IntPtr hWnd, Boolean showFloating) 位置 C:\projects\electronicobserverextended\ElectronicObserver\Window\Integrate\FormIntegrated.cs:行号 265
...
```