### PR TITLE
Move setting Text to Form_Shown

### DIFF
--- a/ElectronicObserver/Window/FormMain.cs
+++ b/ElectronicObserver/Window/FormMain.cs
@@ -69,6 +69,8 @@ namespace ElectronicObserver.Window {
 
 		public FormMain() {
 			InitializeComponent();
+
+			this.Text = SoftwareInformation.VersionJapanese;
 		}
 
 		private async void FormMain_Load( object sender, EventArgs e ) {
@@ -94,8 +96,6 @@ namespace ElectronicObserver.Window {
 
 			Utility.Logger.Add( 2, SoftwareInformation.SoftwareNameJapanese + " を起動しています…" );
 
-
-			this.Text = SoftwareInformation.VersionJapanese;
 
 			ResourceManager.Instance.Load();
 			RecordManager.Instance.Load();


### PR DESCRIPTION
This PR hopefully will fix #91.

According to http://stackoverflow.com/a/16343373, task bar might not be updated properly if `Text` property is changed during `Form_Load`.

The solution provided was to use `BeginInvoke`, which actually just changes the execution order. With this the block will get executed some time before/after `Form_Shown` (definitely after `Form_Load` though). So I am just moving the line to `Form_Shown` and hopefully this will work.

A side effect is that user will now see the caption to be '試製七四式電子観測儀' during startup and it will be changed to the proper value after the loading is completed.