### PR TITLE
通知ダイアログの配置を「手動（絶対）」にした場合にテスト通知ダイアログを移動することで表示位置設置を変更できる機能を追加

### DIFF
--- a/ElectronicObserver/Notifier/NotifierBase.cs
+++ b/ElectronicObserver/Notifier/NotifierBase.cs
@@ -226,12 +226,15 @@ namespace ElectronicObserver.Notifier {
 		/// <summary>
 		/// 通知ダイアログを表示します。
 		/// </summary>
-		public void ShowDialog() {
+		public void ShowDialog(System.Windows.Forms.FormClosingEventHandler customClosingHandler = null) {
 
 			if ( ShowsDialog ) {
 				var dialog = new DialogNotifier( DialogData );
 				dialog.FormClosing += dialog_FormClosing;
-				NotifierManager.Instance.ShowNotifier( dialog );
+                if (customClosingHandler != null) {
+                    dialog.FormClosing += customClosingHandler;
+                }
+                NotifierManager.Instance.ShowNotifier( dialog );
 			}
 		}
 
@@ -245,11 +248,19 @@ namespace ElectronicObserver.Notifier {
 		/// <summary>
 		/// 通知を行います。
 		/// </summary>
-		public virtual void Notify() {
+		public virtual void Notify()
+		{
+			Notify(null);
+		}
+
+		/// <summary>
+		/// 終了時のイベントハンドラを指定して通知を行います。
+		/// </summary>
+		public virtual void Notify(System.Windows.Forms.FormClosingEventHandler customClosingHandler) {
 
 			if ( !IsEnabled || IsSilenced ) return;
 
-			ShowDialog();
+			ShowDialog(customClosingHandler);
 			PlaySound();
 
 		}

--- a/ElectronicObserver/Window/Dialog/DialogConfigurationNotifier.cs
+++ b/ElectronicObserver/Window/Dialog/DialogConfigurationNotifier.cs
@@ -290,9 +290,21 @@ namespace ElectronicObserver.Window.Dialog {
 		private void ButtonTest_Click( object sender, EventArgs e ) {
 
 			if ( !SetConfiguration() ) return;
-			_notifier.DialogData.Message = "テスト 通知です。";
-			_notifier.Notify();
 
+			if (_notifier.DialogData.Alignment == NotifierDialogAlignment.Custom ) {
+				_notifier.DialogData.Message = "テスト 通知です。\n移動して閉じるとその位置に表示するよう設定が更新されます。";
+				_notifier.Notify((_sender, _e) => {
+					var dialog = _sender as DialogNotifier;
+					if ( dialog != null ) {
+						_notifier.DialogData.Location = dialog.Location;
+						LocationX.Value = dialog.Location.X;
+						LocationY.Value = dialog.Location.Y;
+					}
+				});
+			} else {
+				_notifier.DialogData.Message = "テスト 通知です。";
+				_notifier.Notify();
+			}
 		}
 
 		private void SoundPathDirectorize_Click( object sender, EventArgs e ) {


### PR DESCRIPTION
通知ダイアログの設定で
- 表示位置を入力
- テスト通知で確認
- ずれてたら修正
- …………

とするのが煩わしかったので、
テスト通知ダイアログを表示したい位置に移動させて閉じればその位置に表示するよう設定する機能を追加しました。

ただし、「配置」を「手動（絶対）」に設定した場合だけ動作するようにしています（それ以外の場合は未検証です）。