### PR TITLE
Ignore FIPS Policy (Again)

### DIFF
--- a/ElectronicObserver/App.config
+++ b/ElectronicObserver/App.config
@@ -10,5 +10,6 @@
         <bindingRedirect oldVersion="0.0.0.0-1.2.14.0" newVersion="1.2.14.0" />
       </dependentAssembly>
     </assemblyBinding>
+    <enforceFIPSPolicy enabled="false"/>
   </runtime>
 </configuration>

--- a/ElectronicObserver/Utility/Data/RecordHash.cs
+++ b/ElectronicObserver/Utility/Data/RecordHash.cs
@@ -8,7 +8,7 @@ namespace ElectronicObserver.Utility.Data {
 
 	/// <summary>
 	/// レコードに使用するための MD5 アルゴリズムによるハッシュ計算を行います。
-	/// デフォルトの MD5 クラスを利用した場合、 FIPS が有効な環境下で InvalidOperationException が発生する問題があります。
+	/// デフォルトの MD5 クラスを利用した場合、 FIPS が有効な環境下で InvalidOperationException や TargetInvocationException が発生する問題があります。
 	/// この問題を回避するためのクラスです。
 	/// </summary>
 	/// <remarks>http://support.microsoft.com/kb/811833</remarks>
@@ -27,7 +27,7 @@ namespace ElectronicObserver.Utility.Data {
 				originalHasher = System.Security.Cryptography.MD5.Create();
 
 
-			} catch ( InvalidOperationException ) {
+			} catch ( Exception ) {
 
 				Utility.Logger.Add( 1, "RecordHash: System.Security.Cryptography.MD5 ハッシュが利用できません。独自実装を利用します。" );
 


### PR DESCRIPTION
This is a follow-up for #110. Changes in this PR:

* Allow ignoring system FIPS settings (again). We should generally prefer the system implementation if possible, which provides much better performance.
* Catch any kind of `Exception` in `RecordHash`. In a perfect world we would be catching only `InvalidOperationException` and `TargetInvocationException`, but C# unfortunately does not support multi-catch and I don't feel too bad to just catch-all here.

(.Net might be doing reflection when initializing the hasher, so the exception might be a `TargetInvocationException` with `InvalidOperationException` as `InnerException`)