### PR TITLE
グループ：「で終わる」・「で終わらない」条件を含むフィルタが誤動作しないよに

### DIFF
--- a/ElectronicObserver/Data/ShipGroup/ExpressionData.cs
+++ b/ElectronicObserver/Data/ShipGroup/ExpressionData.cs
@@ -255,20 +255,16 @@ namespace ElectronicObserver.Data.ShipGroup
 					condex = Expression.Not(Expression.Call(memberex, typeof(string).GetMethod("Contains", new Type[] { typeof(string) }), constex));
 					break;
 				case ExpressionOperator.BeginWith:
-					condex = Expression.Equal(Expression.Call(memberex, typeof(string).GetMethod("IndexOf", new Type[] { typeof(string) }), constex), Expression.Constant(0, typeof(int)));
+					condex = Expression.Call(memberex, typeof(string).GetMethod("StartsWith", new Type[] { typeof(string) }), constex);
 					break;
 				case ExpressionOperator.NotBeginWith:
-					condex = Expression.NotEqual(Expression.Call(memberex, typeof(string).GetMethod("IndexOf", new Type[] { typeof(string) }), constex), Expression.Constant(0, typeof(int)));
+					condex = Expression.Not(Expression.Call(memberex, typeof(string).GetMethod("StartsWith", new Type[] { typeof(string) }), constex));
 					break;
-				case ExpressionOperator.EndWith:    // returns memberex.LastIndexOf( constex ) == ( memberex.Length - constex.Length )
-					condex = Expression.Equal(
-						Expression.Call(memberex, typeof(string).GetMethod("LastIndexOf", new Type[] { typeof(string) }), constex),
-						Expression.Subtract(Expression.PropertyOrField(memberex, "Length"), Expression.PropertyOrField(constex, "Length")));
+				case ExpressionOperator.EndWith:
+					condex = Expression.Call(memberex, typeof(string).GetMethod("EndsWith", new Type[] { typeof(string) }), constex);
 					break;
-				case ExpressionOperator.NotEndWith: // returns memberex.LastIndexOf( constex ) != ( memberex.Length - constex.Length )
-					condex = Expression.NotEqual(
-						Expression.Call(memberex, typeof(string).GetMethod("LastIndexOf", new Type[] { typeof(string) }), constex),
-						Expression.Subtract(Expression.PropertyOrField(memberex, "Length"), Expression.PropertyOrField(constex, "Length")));
+				case ExpressionOperator.NotEndWith:
+					condex = Expression.Not(Expression.Call(memberex, typeof(string).GetMethod("EndsWith", new Type[] { typeof(string) }), constex));
 					break;
 				case ExpressionOperator.ArrayContains:  // returns Enumerable.Contains<>( memberex )
 					condex = Expression.Call(typeof(Enumerable), "Contains", new Type[] { memberex.Type.GetElementType() ?? memberex.Type.GetGenericArguments().First() }, memberex, constex);


### PR DESCRIPTION
```C#
case ExpressionOperator.EndWith:    // returns memberex.LastIndexOf( constex ) == ( memberex.Length - constex.Length )
	condex = Expression.Equal(
		Expression.Call(memberex, typeof(string).GetMethod("LastIndexOf", new Type[] { typeof(string) }), constex),
		Expression.Subtract(Expression.PropertyOrField(memberex, "Length"), Expression.PropertyOrField(constex, "Length")));
	break;
```
例えば艦名は「ＸＸＸＸ（**４文字**）で終わる」を条件にするど、入力内容をかかわらす、艦名は**３文字**の艦はすべてこの条件にあたる（```LastIndexOf = -1``` ) 。修正可能だが、そもそもなぜ ```EndsWith``` でわなく、こういう面倒な方法を選んだし…

「から始まる」・「から始まらない」についで、同じような誤動作の可能性はないが、一応 ```StartsWith``` にかわりました。