### PR TITLE
戦闘詳細：攻撃方向表示するとき、味方艦を左側に置く

### DIFF
--- a/ElectronicObserver/Data/Battle/Detail/BattleDetail.cs
+++ b/ElectronicObserver/Data/Battle/Detail/BattleDetail.cs
@@ -149,7 +149,11 @@ namespace ElectronicObserver.Data.Battle.Detail
 
 			StringBuilder builder = new StringBuilder();
 
-			builder.AppendFormat("{0} → {1}\r\n", GetAttackerName(), GetDefenderName());
+			// 航空戦・支援攻撃時 AttackerIndex = BattleIndex.Invalid 、それで AttackerIndex.Side = BattleSides.FriendMain になる
+			// DefenderIndex.Side で判断すれば航空戦も正確に識別できるが表示が変になるので、最終的には AttackerIndex.Side で判断しだ
+			bool attackerIsFriend = AttackerIndex.Side == BattleSides.FriendMain || AttackerIndex.Side == BattleSides.FriendEscort;
+
+			builder.AppendFormat(attackerIsFriend ? "{0} → {1}\r\n" : "{1} ← {0}\r\n", GetAttackerName(), GetDefenderName());
 
 
 			if (AttackType >= 0)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2091529/34401579-8fa6e688-ebdf-11e7-8411-d7d9a553f653.png)
通常出撃にわ特に問題ないが、演習において相手側同じ艦娘がいる場合、どっちがどっちに攻撃しているがよくわからなくなる。この問題を解消するため、味方艦常に左側に置きます。

航空戦について、攻撃側の表印は「敵軍航空隊」・「自軍航空隊」なんで、この問題は存在しません。支援攻撃について、敵軍支援攻撃まだ無い、例え今後あるどすれば、航空戦同様に攻撃側の表印で区別つかれる。それゆえ、航空戦・支援攻撃には変化なし（防御側か右側に置く）。