### PR TITLE
対空砲火詳細：敵スロット機数直接入力すると落ちる不具合を修正

### DIFF
--- a/ElectronicObserver/Window/Dialog/DialogAntiAirDefense.Designer.cs
+++ b/ElectronicObserver/Window/Dialog/DialogAntiAirDefense.Designer.cs
@@ -204,6 +204,11 @@
 			0,
 			0,
 			0});
+			this.EnemySlotCount.Minimum = new decimal(new int[] {
+			1,
+			0,
+			0,
+			0});
 			this.EnemySlotCount.Name = "EnemySlotCount";
 			this.EnemySlotCount.Size = new System.Drawing.Size(80, 23);
 			this.EnemySlotCount.TabIndex = 2;

--- a/ElectronicObserver/Window/Dialog/DialogAntiAirDefense.cs
+++ b/ElectronicObserver/Window/Dialog/DialogAntiAirDefense.cs
@@ -55,9 +55,12 @@ namespace ElectronicObserver.Window.Dialog
 		}
 
 
+		private int enemySlotCountValue;
+
 		public DialogAntiAirDefense()
 		{
 			InitializeComponent();
+			enemySlotCountValue = (int)EnemySlotCount.Value;
 		}
 
 		private void DialogAntiAirDefense_Load(object sender, EventArgs e)
@@ -96,7 +99,7 @@ namespace ElectronicObserver.Window.Dialog
 			ShipData[] ships = GetShips().ToArray();
 			int formation = Formation.SelectedItem as FormationComboBoxData;
 			int aaCutinKind = AACutinKind.SelectedItem as AACutinComboBoxData;
-			int enemyAircraftCount = (int)EnemySlotCount.Value;
+			int enemyAircraftCount = enemySlotCountValue;
 
 
 			// 加重対空値
@@ -215,7 +218,7 @@ namespace ElectronicObserver.Window.Dialog
 			{
 
 				int value = e.Value as int? ?? 0;
-				int enemySlot = (int)EnemySlotCount.Value;
+				int enemySlot = enemySlotCountValue;
 
 				e.Value = string.Format("{0} ({1:p0})", value, (double)value / enemySlot);
 				e.FormattingApplied = true;
@@ -246,6 +249,7 @@ namespace ElectronicObserver.Window.Dialog
 
 		private void EnemySlotCount_ValueChanged(object sender, EventArgs e)
 		{
+			enemySlotCountValue = (int)EnemySlotCount.Value;
 			Updated();
 		}
 


### PR DESCRIPTION
敵スロット機数を直接入力する時なぜが ```EnemySlotCount.Value``` Null になる、~~代わりに ```int.Parse(EnemySlotCount.Text)``` 使います。~~ まだ、最小値を０から１に変更。