### PR TITLE
Add equipment modification info display in main equipment list

### DIFF
--- a/ElectronicObserver/Window/Dialog/DialogEquipmentList.Designer.cs
+++ b/ElectronicObserver/Window/Dialog/DialogEquipmentList.Designer.cs
@@ -28,243 +28,256 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.EquipmentView = new System.Windows.Forms.DataGridView();
-			this.EquipmentView_ID = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.EquipmentView_Icon = new System.Windows.Forms.DataGridViewImageColumn();
-			this.EquipmentView_Name = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.EquipmentView_CountAll = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.EquipmentView_CountRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.TopMenu = new System.Windows.Forms.MenuStrip();
-			this.TopMenu_File = new System.Windows.Forms.ToolStripMenuItem();
-			this.TopMenu_File_CSVOutput = new System.Windows.Forms.ToolStripMenuItem();
-			this.TopMenu_File_Update = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveCSVDialog = new System.Windows.Forms.SaveFileDialog();
-			this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-			this.DetailView = new System.Windows.Forms.DataGridView();
-			this.DetailView_Level = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.DetailView_AircraftLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.DetailView_CountAll = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.DetailView_CountRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.DetailView_EquippedShip = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			((System.ComponentModel.ISupportInitialize)(this.EquipmentView)).BeginInit();
-			this.TopMenu.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-			this.splitContainer1.Panel1.SuspendLayout();
-			this.splitContainer1.Panel2.SuspendLayout();
-			this.splitContainer1.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.DetailView)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// EquipmentView
-			// 
-			this.EquipmentView.AllowUserToAddRows = false;
-			this.EquipmentView.AllowUserToDeleteRows = false;
-			this.EquipmentView.AllowUserToResizeRows = false;
-			this.EquipmentView.BackgroundColor = System.Drawing.SystemColors.Control;
-			this.EquipmentView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-			this.EquipmentView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-			this.EquipmentView_ID,
-			this.EquipmentView_Icon,
-			this.EquipmentView_Name,
-			this.EquipmentView_CountAll,
-			this.EquipmentView_CountRemain});
-			this.EquipmentView.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.EquipmentView.Location = new System.Drawing.Point(0, 0);
-			this.EquipmentView.Name = "EquipmentView";
-			this.EquipmentView.ReadOnly = true;
-			this.EquipmentView.RowHeadersVisible = false;
-			this.EquipmentView.RowTemplate.Height = 21;
-			this.EquipmentView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-			this.EquipmentView.Size = new System.Drawing.Size(320, 456);
-			this.EquipmentView.TabIndex = 0;
-			this.EquipmentView.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.EquipmentView_CellFormatting);
-			this.EquipmentView.SelectionChanged += new System.EventHandler(this.EquipmentView_SelectionChanged);
-			this.EquipmentView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.EquipmentView_SortCompare);
-			this.EquipmentView.Sorted += new System.EventHandler(this.EquipmentView_Sorted);
-			// 
-			// EquipmentView_ID
-			// 
-			this.EquipmentView_ID.HeaderText = "ID";
-			this.EquipmentView_ID.Name = "EquipmentView_ID";
-			this.EquipmentView_ID.ReadOnly = true;
-			this.EquipmentView_ID.Width = 40;
-			// 
-			// EquipmentView_Icon
-			// 
-			this.EquipmentView_Icon.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
-			this.EquipmentView_Icon.HeaderText = "";
-			this.EquipmentView_Icon.Name = "EquipmentView_Icon";
-			this.EquipmentView_Icon.ReadOnly = true;
-			this.EquipmentView_Icon.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-			this.EquipmentView_Icon.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-			this.EquipmentView_Icon.Width = 5;
-			// 
-			// EquipmentView_Name
-			// 
-			this.EquipmentView_Name.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-			this.EquipmentView_Name.HeaderText = "装備名";
-			this.EquipmentView_Name.Name = "EquipmentView_Name";
-			this.EquipmentView_Name.ReadOnly = true;
-			// 
-			// EquipmentView_CountAll
-			// 
-			this.EquipmentView_CountAll.HeaderText = "全個数";
-			this.EquipmentView_CountAll.Name = "EquipmentView_CountAll";
-			this.EquipmentView_CountAll.ReadOnly = true;
-			this.EquipmentView_CountAll.Width = 40;
-			// 
-			// EquipmentView_CountRemain
-			// 
-			this.EquipmentView_CountRemain.HeaderText = "余個数";
-			this.EquipmentView_CountRemain.Name = "EquipmentView_CountRemain";
-			this.EquipmentView_CountRemain.ReadOnly = true;
-			this.EquipmentView_CountRemain.Width = 40;
-			// 
-			// TopMenu
-			// 
-			this.TopMenu.ImageScalingSize = new System.Drawing.Size(32, 32);
-			this.TopMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.TopMenu_File});
-			this.TopMenu.Location = new System.Drawing.Point(0, 0);
-			this.TopMenu.Name = "TopMenu";
-			this.TopMenu.Size = new System.Drawing.Size(640, 24);
-			this.TopMenu.TabIndex = 1;
-			this.TopMenu.Text = "menuStrip1";
-			// 
-			// TopMenu_File
-			// 
-			this.TopMenu_File.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.TopMenu_File_CSVOutput,
-			this.TopMenu_File_Update});
-			this.TopMenu_File.Name = "TopMenu_File";
-			this.TopMenu_File.Size = new System.Drawing.Size(70, 20);
-			this.TopMenu_File.Text = "ファイル(&F)";
-			// 
-			// TopMenu_File_CSVOutput
-			// 
-			this.TopMenu_File_CSVOutput.Name = "TopMenu_File_CSVOutput";
-			this.TopMenu_File_CSVOutput.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.TopMenu_File_CSVOutput.Size = new System.Drawing.Size(198, 22);
-			this.TopMenu_File_CSVOutput.Text = "CSV出力(&C)...";
-			this.TopMenu_File_CSVOutput.Click += new System.EventHandler(this.Menu_File_CSVOutput_Click);
-			// 
-			// TopMenu_File_Update
-			// 
-			this.TopMenu_File_Update.Name = "TopMenu_File_Update";
-			this.TopMenu_File_Update.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.R)));
-			this.TopMenu_File_Update.Size = new System.Drawing.Size(198, 22);
-			this.TopMenu_File_Update.Text = "更新(&U)";
-			this.TopMenu_File_Update.Click += new System.EventHandler(this.TopMenu_File_Update_Click);
-			// 
-			// SaveCSVDialog
-			// 
-			this.SaveCSVDialog.Filter = "CSV|*.csv|File|*";
-			this.SaveCSVDialog.Title = "CSVに出力";
-			// 
-			// splitContainer1
-			// 
-			this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.splitContainer1.Location = new System.Drawing.Point(0, 24);
-			this.splitContainer1.Name = "splitContainer1";
-			// 
-			// splitContainer1.Panel1
-			// 
-			this.splitContainer1.Panel1.Controls.Add(this.EquipmentView);
-			// 
-			// splitContainer1.Panel2
-			// 
-			this.splitContainer1.Panel2.Controls.Add(this.DetailView);
-			this.splitContainer1.Size = new System.Drawing.Size(640, 456);
-			this.splitContainer1.SplitterDistance = 320;
-			this.splitContainer1.TabIndex = 2;
-			// 
-			// DetailView
-			// 
-			this.DetailView.AllowUserToAddRows = false;
-			this.DetailView.AllowUserToDeleteRows = false;
-			this.DetailView.AllowUserToResizeRows = false;
-			this.DetailView.BackgroundColor = System.Drawing.SystemColors.Control;
-			this.DetailView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-			this.DetailView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-			this.DetailView_Level,
-			this.DetailView_AircraftLevel,
-			this.DetailView_CountAll,
-			this.DetailView_CountRemain,
-			this.DetailView_EquippedShip});
-			this.DetailView.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.DetailView.Location = new System.Drawing.Point(0, 0);
-			this.DetailView.Name = "DetailView";
-			this.DetailView.ReadOnly = true;
-			this.DetailView.RowHeadersVisible = false;
-			this.DetailView.RowTemplate.Height = 21;
-			this.DetailView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-			this.DetailView.Size = new System.Drawing.Size(316, 456);
-			this.DetailView.TabIndex = 1;
-			this.DetailView.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DetailView_CellFormatting);
-			this.DetailView.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.DetailView_CellPainting);
-			this.DetailView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.DetailView_SortCompare);
-			this.DetailView.Sorted += new System.EventHandler(this.DetailView_Sorted);
-			// 
-			// DetailView_Level
-			// 
-			this.DetailView_Level.HeaderText = "改修";
-			this.DetailView_Level.Name = "DetailView_Level";
-			this.DetailView_Level.ReadOnly = true;
-			this.DetailView_Level.Width = 40;
-			// 
-			// DetailView_AircraftLevel
-			// 
-			this.DetailView_AircraftLevel.HeaderText = "練度";
-			this.DetailView_AircraftLevel.Name = "DetailView_AircraftLevel";
-			this.DetailView_AircraftLevel.ReadOnly = true;
-			this.DetailView_AircraftLevel.Width = 40;
-			// 
-			// DetailView_CountAll
-			// 
-			this.DetailView_CountAll.HeaderText = "全個数";
-			this.DetailView_CountAll.Name = "DetailView_CountAll";
-			this.DetailView_CountAll.ReadOnly = true;
-			this.DetailView_CountAll.Width = 40;
-			// 
-			// DetailView_CountRemain
-			// 
-			this.DetailView_CountRemain.HeaderText = "余個数";
-			this.DetailView_CountRemain.Name = "DetailView_CountRemain";
-			this.DetailView_CountRemain.ReadOnly = true;
-			this.DetailView_CountRemain.Width = 40;
-			// 
-			// DetailView_EquippedShip
-			// 
-			this.DetailView_EquippedShip.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-			this.DetailView_EquippedShip.HeaderText = "装備艦";
-			this.DetailView_EquippedShip.Name = "DetailView_EquippedShip";
-			this.DetailView_EquippedShip.ReadOnly = true;
-			this.DetailView_EquippedShip.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-			// 
-			// DialogEquipmentList
-			// 
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-			this.ClientSize = new System.Drawing.Size(640, 480);
-			this.Controls.Add(this.splitContainer1);
-			this.Controls.Add(this.TopMenu);
-			this.DoubleBuffered = true;
-			this.Font = new System.Drawing.Font("Meiryo UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
-			this.MainMenuStrip = this.TopMenu;
-			this.Name = "DialogEquipmentList";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "装備一覧";
-			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.DialogEquipmentList_FormClosed);
-			this.Load += new System.EventHandler(this.DialogEquipmentList_Load);
-			((System.ComponentModel.ISupportInitialize)(this.EquipmentView)).EndInit();
-			this.TopMenu.ResumeLayout(false);
-			this.TopMenu.PerformLayout();
-			this.splitContainer1.Panel1.ResumeLayout(false);
-			this.splitContainer1.Panel2.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-			this.splitContainer1.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.DetailView)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.EquipmentView = new System.Windows.Forms.DataGridView();
+            this.EquipmentView_ID = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.EquipmentView_Icon = new System.Windows.Forms.DataGridViewImageColumn();
+            this.EquipmentView_Name = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.EquipmentView_CountAll = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.EquipmentView_CountRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.TopMenu = new System.Windows.Forms.MenuStrip();
+            this.TopMenu_File = new System.Windows.Forms.ToolStripMenuItem();
+            this.TopMenu_File_CSVOutput = new System.Windows.Forms.ToolStripMenuItem();
+            this.TopMenu_File_Update = new System.Windows.Forms.ToolStripMenuItem();
+            this.SaveCSVDialog = new System.Windows.Forms.SaveFileDialog();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.DetailView = new System.Windows.Forms.DataGridView();
+            this.DetailView_Level = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DetailView_AircraftLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DetailView_CountAll = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DetailView_CountRemain = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DetailView_EquippedShip = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.labelLoading = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.EquipmentView)).BeginInit();
+            this.TopMenu.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.DetailView)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // EquipmentView
+            // 
+            this.EquipmentView.AllowUserToAddRows = false;
+            this.EquipmentView.AllowUserToDeleteRows = false;
+            this.EquipmentView.AllowUserToResizeRows = false;
+            this.EquipmentView.BackgroundColor = System.Drawing.SystemColors.Control;
+            this.EquipmentView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
+            this.EquipmentView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.EquipmentView_ID,
+            this.EquipmentView_Icon,
+            this.EquipmentView_Name,
+            this.EquipmentView_CountAll,
+            this.EquipmentView_CountRemain});
+            this.EquipmentView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.EquipmentView.Location = new System.Drawing.Point(0, 0);
+            this.EquipmentView.Name = "EquipmentView";
+            this.EquipmentView.ReadOnly = true;
+            this.EquipmentView.RowHeadersVisible = false;
+            this.EquipmentView.RowTemplate.Height = 21;
+            this.EquipmentView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.EquipmentView.Size = new System.Drawing.Size(492, 536);
+            this.EquipmentView.TabIndex = 0;
+            this.EquipmentView.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.EquipmentView_CellFormatting);
+            this.EquipmentView.SelectionChanged += new System.EventHandler(this.EquipmentView_SelectionChanged);
+            this.EquipmentView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.EquipmentView_SortCompare);
+            this.EquipmentView.Sorted += new System.EventHandler(this.EquipmentView_Sorted);
+            // 
+            // EquipmentView_ID
+            // 
+            this.EquipmentView_ID.HeaderText = "ID";
+            this.EquipmentView_ID.Name = "EquipmentView_ID";
+            this.EquipmentView_ID.ReadOnly = true;
+            this.EquipmentView_ID.Width = 40;
+            // 
+            // EquipmentView_Icon
+            // 
+            this.EquipmentView_Icon.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
+            this.EquipmentView_Icon.HeaderText = "";
+            this.EquipmentView_Icon.Name = "EquipmentView_Icon";
+            this.EquipmentView_Icon.ReadOnly = true;
+            this.EquipmentView_Icon.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.EquipmentView_Icon.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.EquipmentView_Icon.Width = 5;
+            // 
+            // EquipmentView_Name
+            // 
+            this.EquipmentView_Name.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.EquipmentView_Name.HeaderText = "装備名";
+            this.EquipmentView_Name.Name = "EquipmentView_Name";
+            this.EquipmentView_Name.ReadOnly = true;
+            // 
+            // EquipmentView_CountAll
+            // 
+            this.EquipmentView_CountAll.HeaderText = "全個数";
+            this.EquipmentView_CountAll.Name = "EquipmentView_CountAll";
+            this.EquipmentView_CountAll.ReadOnly = true;
+            this.EquipmentView_CountAll.Width = 40;
+            // 
+            // EquipmentView_CountRemain
+            // 
+            this.EquipmentView_CountRemain.HeaderText = "余個数";
+            this.EquipmentView_CountRemain.Name = "EquipmentView_CountRemain";
+            this.EquipmentView_CountRemain.ReadOnly = true;
+            this.EquipmentView_CountRemain.Width = 40;
+            // 
+            // TopMenu
+            // 
+            this.TopMenu.ImageScalingSize = new System.Drawing.Size(32, 32);
+            this.TopMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.TopMenu_File});
+            this.TopMenu.Location = new System.Drawing.Point(0, 0);
+            this.TopMenu.Name = "TopMenu";
+            this.TopMenu.Size = new System.Drawing.Size(984, 25);
+            this.TopMenu.TabIndex = 1;
+            this.TopMenu.Text = "menuStrip1";
+            // 
+            // TopMenu_File
+            // 
+            this.TopMenu_File.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.TopMenu_File_CSVOutput,
+            this.TopMenu_File_Update});
+            this.TopMenu_File.Name = "TopMenu_File";
+            this.TopMenu_File.Size = new System.Drawing.Size(82, 21);
+            this.TopMenu_File.Text = "ファイル(&F)";
+            // 
+            // TopMenu_File_CSVOutput
+            // 
+            this.TopMenu_File_CSVOutput.Name = "TopMenu_File_CSVOutput";
+            this.TopMenu_File_CSVOutput.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+            this.TopMenu_File_CSVOutput.Size = new System.Drawing.Size(192, 22);
+            this.TopMenu_File_CSVOutput.Text = "CSV出力(&C)...";
+            this.TopMenu_File_CSVOutput.Click += new System.EventHandler(this.Menu_File_CSVOutput_Click);
+            // 
+            // TopMenu_File_Update
+            // 
+            this.TopMenu_File_Update.Name = "TopMenu_File_Update";
+            this.TopMenu_File_Update.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.R)));
+            this.TopMenu_File_Update.Size = new System.Drawing.Size(192, 22);
+            this.TopMenu_File_Update.Text = "更新(&U)";
+            this.TopMenu_File_Update.Click += new System.EventHandler(this.TopMenu_File_Update_Click);
+            // 
+            // SaveCSVDialog
+            // 
+            this.SaveCSVDialog.Filter = "CSV|*.csv|File|*";
+            this.SaveCSVDialog.Title = "CSVに出力";
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 25);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.labelLoading);
+            this.splitContainer1.Panel1.Controls.Add(this.EquipmentView);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.DetailView);
+            this.splitContainer1.Size = new System.Drawing.Size(984, 536);
+            this.splitContainer1.SplitterDistance = 492;
+            this.splitContainer1.TabIndex = 2;
+            // 
+            // DetailView
+            // 
+            this.DetailView.AllowUserToAddRows = false;
+            this.DetailView.AllowUserToDeleteRows = false;
+            this.DetailView.AllowUserToResizeRows = false;
+            this.DetailView.BackgroundColor = System.Drawing.SystemColors.Control;
+            this.DetailView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
+            this.DetailView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.DetailView_Level,
+            this.DetailView_AircraftLevel,
+            this.DetailView_CountAll,
+            this.DetailView_CountRemain,
+            this.DetailView_EquippedShip});
+            this.DetailView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.DetailView.Location = new System.Drawing.Point(0, 0);
+            this.DetailView.Name = "DetailView";
+            this.DetailView.ReadOnly = true;
+            this.DetailView.RowHeadersVisible = false;
+            this.DetailView.RowTemplate.Height = 21;
+            this.DetailView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.DetailView.Size = new System.Drawing.Size(488, 536);
+            this.DetailView.TabIndex = 1;
+            this.DetailView.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DetailView_CellFormatting);
+            this.DetailView.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.DetailView_CellPainting);
+            this.DetailView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.DetailView_SortCompare);
+            this.DetailView.Sorted += new System.EventHandler(this.DetailView_Sorted);
+            // 
+            // DetailView_Level
+            // 
+            this.DetailView_Level.HeaderText = "改修";
+            this.DetailView_Level.Name = "DetailView_Level";
+            this.DetailView_Level.ReadOnly = true;
+            this.DetailView_Level.Width = 40;
+            // 
+            // DetailView_AircraftLevel
+            // 
+            this.DetailView_AircraftLevel.HeaderText = "練度";
+            this.DetailView_AircraftLevel.Name = "DetailView_AircraftLevel";
+            this.DetailView_AircraftLevel.ReadOnly = true;
+            this.DetailView_AircraftLevel.Width = 40;
+            // 
+            // DetailView_CountAll
+            // 
+            this.DetailView_CountAll.HeaderText = "全個数";
+            this.DetailView_CountAll.Name = "DetailView_CountAll";
+            this.DetailView_CountAll.ReadOnly = true;
+            this.DetailView_CountAll.Width = 40;
+            // 
+            // DetailView_CountRemain
+            // 
+            this.DetailView_CountRemain.HeaderText = "余個数";
+            this.DetailView_CountRemain.Name = "DetailView_CountRemain";
+            this.DetailView_CountRemain.ReadOnly = true;
+            this.DetailView_CountRemain.Width = 40;
+            // 
+            // DetailView_EquippedShip
+            // 
+            this.DetailView_EquippedShip.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.DetailView_EquippedShip.HeaderText = "装備艦";
+            this.DetailView_EquippedShip.Name = "DetailView_EquippedShip";
+            this.DetailView_EquippedShip.ReadOnly = true;
+            this.DetailView_EquippedShip.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
+            // labelLoading
+            // 
+            this.labelLoading.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.labelLoading.AutoSize = true;
+            this.labelLoading.Location = new System.Drawing.Point(211, 246);
+            this.labelLoading.Name = "labelLoading";
+            this.labelLoading.Size = new System.Drawing.Size(64, 15);
+            this.labelLoading.TabIndex = 1;
+            this.labelLoading.Text = "Loading...";
+            // 
+            // DialogEquipmentList
+            // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            this.ClientSize = new System.Drawing.Size(984, 561);
+            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.TopMenu);
+            this.DoubleBuffered = true;
+            this.Font = new System.Drawing.Font("Meiryo UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
+            this.MainMenuStrip = this.TopMenu;
+            this.Name = "DialogEquipmentList";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "装備一覧";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.DialogEquipmentList_FormClosed);
+            this.Load += new System.EventHandler(this.DialogEquipmentList_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.EquipmentView)).EndInit();
+            this.TopMenu.ResumeLayout(false);
+            this.TopMenu.PerformLayout();
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.DetailView)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -288,5 +301,6 @@
 		private System.Windows.Forms.DataGridViewTextBoxColumn DetailView_CountAll;
 		private System.Windows.Forms.DataGridViewTextBoxColumn DetailView_CountRemain;
 		private System.Windows.Forms.DataGridViewTextBoxColumn DetailView_EquippedShip;
-	}
+        private System.Windows.Forms.Label labelLoading;
+    }
 }

--- a/ElectronicObserver/Window/Dialog/DialogEquipmentList.resx
+++ b/ElectronicObserver/Window/Dialog/DialogEquipmentList.resx
@@ -132,21 +132,6 @@
   <metadata name="EquipmentView_CountRemain.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="EquipmentView_ID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="EquipmentView_Icon.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="EquipmentView_Name.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="EquipmentView_CountAll.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="EquipmentView_CountRemain.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="TopMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>


### PR DESCRIPTION
Because the last submission wrongly modified the original develop code, so resubmitted.
I think every equipment needs to be clicked to see modification Info is too much trouble.  equipment list may have a better way to show...