### PR TITLE
Fix : fleet panel is not refreshing after removing all accompanying ships

### DIFF
--- a/ElectronicObserver/Data/FleetData.cs
+++ b/ElectronicObserver/Data/FleetData.cs
@@ -185,7 +185,7 @@ namespace ElectronicObserver.Data
 
 						if (FleetID == fleetID)
 						{
-							if (index == -1)
+							if (index == 0 && shipID == -2)
 							{
 								//旗艦以外全解除
 								for (int i = 1; i < _members.Length; i++)


### PR DESCRIPTION
Found that requesting parameters for removing all accompanying ships in 編成 page have been changed, so I changed the related if-condition to make it refresh normally