### PR TITLE
彗星一二型(三一号光電管爆弾搭載機)の空母夜襲対応

### DIFF
--- a/ElectronicObserver/Data/ShipData.cs
+++ b/ElectronicObserver/Data/ShipData.cs
@@ -1198,11 +1198,11 @@ namespace ElectronicObserver.Data
 
                 basepower = FirepowerBase +
                     airs.Where(p => p.master.IsNightAircraft)
-                        .Sum(p => p.master.Firepower + p.master.Torpedo +
+                        .Sum(p => p.master.Firepower + p.master.Torpedo + p.master.Bomber +
                             3 * p.count +
                             0.45 * (p.master.Firepower + p.master.Torpedo + p.master.Bomber + p.master.ASW) * Math.Sqrt(p.count) + Math.Sqrt(p.eq.Level)) +
-                    airs.Where(p => p.master.IsSwordfish || p.master.EquipmentID == 154)   // 零戦62型(爆戦/岩井隊)
-                        .Sum(p => p.master.Firepower + p.master.Torpedo +
+                    airs.Where(p => p.master.IsSwordfish || p.master.EquipmentID == 154 || p.master.EquipmentID == 320)   // 零戦62型(爆戦/岩井隊)、彗星一二型(三一号光電管爆弾搭載機)
+                        .Sum(p => p.master.Firepower + p.master.Torpedo + p.master.Bomber +
                             0.3 * (p.master.Firepower + p.master.Torpedo + p.master.Bomber + p.master.ASW) * Math.Sqrt(p.count) + Math.Sqrt(p.eq.Level));
 
             }
@@ -1261,9 +1261,12 @@ namespace ElectronicObserver.Data
                     {
                         int nightFighter = SlotInstanceMaster.Count(eq => eq?.IsNightFighter ?? false);
                         int nightAttacker = SlotInstanceMaster.Count(eq => eq?.IsNightAttacker ?? false);
+                        int nightBomber = SlotInstanceMaster.Count(eq => eq?.EquipmentID == 320);     // 彗星一二型(三一号光電管爆弾搭載機)
 
                         if (nightFighter >= 2 && nightAttacker >= 1)
                             basepower *= 1.25;
+                        else if (nightBomber >= 1 && nightFighter + nightAttacker >= 1)
+                            basepower *= 1.2;
                         else if (nightFighter >= 1 && nightAttacker >= 1)
                             basepower *= 1.2;
                         else

--- a/ElectronicObserver/Utility/Data/Calculator.cs
+++ b/ElectronicObserver/Utility/Data/Calculator.cs
@@ -895,6 +895,7 @@ namespace ElectronicObserver.Utility.Data
             int nightFighterCount = 0;
             int nightAttackerCount = 0;
             int swordfishCount = 0;
+            int nightCapableBomberCount = 0;
             int nightBomberCount = 0;
             int nightPersonnelCount = 0;
             int surfaceRadarCount = 0;
@@ -945,6 +946,8 @@ namespace ElectronicObserver.Utility.Data
                     // (夜間)爆撃機
                     case EquipmentTypes.CarrierBasedBomber:
                         if (eq.EquipmentID == 154)      // 零戦62型(爆戦/岩井隊)
+                            nightCapableBomberCount++;
+                        else if (eq.EquipmentID == 320) // 彗星一二型(三一号光電管爆弾搭載機)
                             nightBomberCount++;
                         break;
 
@@ -1023,12 +1026,13 @@ namespace ElectronicObserver.Utility.Data
                     (subGunCount >= 2 && torpedoCount <= 1))
                     return NightAttackKind.DoubleShelling;
 
-
                 // 空母カットイン
-                if (nightPersonnelCount > 0 && nightFighterCount > 0)
+                if (nightPersonnelCount > 0)
                 {
-                    if (nightAttackerCount > 0 ||
-                        (nightFighterCount + swordfishCount + nightBomberCount) >= 3)
+                    if (nightFighterCount > 0 &&
+                        (nightAttackerCount > 0 || (nightFighterCount + swordfishCount + nightCapableBomberCount) >= 3))
+                        return NightAttackKind.CutinAirAttack;
+                    else if (nightBomberCount > 0 && (nightFighterCount + nightAttackerCount > 0))
                         return NightAttackKind.CutinAirAttack;
                 }
 


### PR DESCRIPTION
* 爆装を基本攻撃力に加算するように変更（https://twitter.com/wedge503/status/1123528702220890113）
* 彗星一二型(三一号光電管爆弾搭載機)の夜間攻撃力計算式は岩井爆戦のものと同様（https://kancolle.fandom.com/wiki/Combat?oldid=1097460#/Damage_Calculation ※爆装の加算は反映されていない模様）
* 空母夜襲CIは従来の組み合わせに加えて、夜間爆撃機1↑＋(夜間戦闘機＋夜間攻撃機)1↑で発生（https://kancolle.fandom.com/wiki/Combat?oldid=1097460#/Night_Battle）

命名規則：
* 夜間対応爆撃機（Night Capable Bomber）：零戦62型(爆戦/岩井隊)
* 夜間爆撃機（Night Bomber）：彗星一二型(三一号光電管爆弾搭載機)