### PR TITLE
Fix a time zone related quest fail-to-reset bug. 

### DIFF
--- a/ElectronicObserver/Utility/Mathematics/DateTimeHelper.cs
+++ b/ElectronicObserver/Utility/Mathematics/DateTimeHelper.cs
@@ -123,42 +123,42 @@ namespace ElectronicObserver.Utility.Mathematics
 		}
 
 
-		/// <summary>
-		/// 指定した日時をまたいでいるかを取得します。日単位で処理されます。
-		/// </summary>
-		/// <param name="prev">前回処理した時の日時。</param>
-		/// <param name="hours">指定した日時の時間。</param>
-		/// <param name="minutes">指定した日時の分。</param>
-		/// <param name="seconds">指定した日時の秒。</param>
-		/// <returns></returns>
-		public static bool IsCrossedDay(DateTime prev, int hours, int minutes, int seconds)
+        /// <summary>
+        /// 指定した日時をまたいでいるかを取得します。日単位で処理されます。
+        /// </summary>
+        /// <param name="prev">前回処理した時の（現地）日時。</param>
+        /// <param name="hours">指定した日時の時間。</param>
+        /// <param name="minutes">指定した日時の分。</param>
+        /// <param name="seconds">指定した日時の秒。</param>
+        /// <returns></returns>
+        public static bool IsCrossedDay(DateTime prev, int hours, int minutes, int seconds)
 		{
 
-			DateTime now = DateTime.Now;
+			DateTime now = GetJapanStandardTimeNow();
 
 			TimeSpan nowtime = now.TimeOfDay;
-			TimeSpan bordertime = new TimeSpan(hours, minutes, seconds) + GetTimeDifference();
+			TimeSpan bordertime = new TimeSpan(hours, minutes, seconds);
 
-			return IsCrossed(prev, now.Subtract(new TimeSpan(nowtime < bordertime ? 1 : 0, nowtime.Hours, nowtime.Minutes, nowtime.Seconds)).Add(bordertime));
+			return IsCrossed(GetJapanStandardTime(prev), now.Subtract(new TimeSpan(nowtime < bordertime ? 1 : 0, nowtime.Hours, nowtime.Minutes, nowtime.Seconds)).Add(bordertime));
 		}
 
 
-		/// <summary>
-		/// 指定した日時をまたいでいるかを取得します。週単位で処理されます。
-		/// </summary>
-		/// <param name="prev">前回処理した時の日時。</param>
-		/// <param name="dayOfWeek">指定した日時の曜日。</param>
-		/// <param name="hours">指定した日時の時間。</param>
-		/// <param name="minutes">指定した日時の分。</param>
-		/// <param name="seconds">指定した日時の秒。</param>
-		/// <returns></returns>
-		public static bool IsCrossedWeek(DateTime prev, DayOfWeek dayOfWeek, int hours, int minutes, int seconds)
+        /// <summary>
+        /// 指定した日時をまたいでいるかを取得します。週単位で処理されます。
+        /// </summary>
+        /// <param name="prev">前回処理した時の（現地）日時。</param>
+        /// <param name="dayOfWeek">指定した日時の曜日。</param>
+        /// <param name="hours">指定した日時の時間。</param>
+        /// <param name="minutes">指定した日時の分。</param>
+        /// <param name="seconds">指定した日時の秒。</param>
+        /// <returns></returns>
+        public static bool IsCrossedWeek(DateTime prev, DayOfWeek dayOfWeek, int hours, int minutes, int seconds)
 		{
 
-			DateTime now = DateTime.Now;
+			DateTime now = GetJapanStandardTimeNow();
 
 			TimeSpan nowtime = now.TimeOfDay;
-			TimeSpan bordertime = new TimeSpan(hours, minutes, seconds) + GetTimeDifference();
+			TimeSpan bordertime = new TimeSpan(hours, minutes, seconds);
 
 			int dayshift = now.DayOfWeek - dayOfWeek;
 			if (dayshift < 0)
@@ -168,50 +168,50 @@ namespace ElectronicObserver.Utility.Mathematics
 
 			DateTime border = now.Subtract(new TimeSpan(dayshift, nowtime.Hours, nowtime.Minutes, nowtime.Seconds)).Add(bordertime);
 
-			return IsCrossed(prev, border);
+			return IsCrossed(GetJapanStandardTime(prev), border);
 		}
 
 
-		/// <summary>
-		/// 指定した日時をまたいでいるかを取得します。月単位で処理されます。
-		/// </summary>
-		/// <param name="prev">前回処理した時の日時。</param>
-		/// <param name="days">指定した日時の日付。</param>
-		/// <param name="hours">指定した日時の時間。</param>
-		/// <param name="minutes">指定した日時の分。</param>
-		/// <param name="seconds">指定した日時の秒。</param>
-		/// <returns></returns>
-		public static bool IsCrossedMonth(DateTime prev, int days, int hours, int minutes, int seconds)
+        /// <summary>
+        /// 指定した日時をまたいでいるかを取得します。月単位で処理されます。
+        /// </summary>
+        /// <param name="prev">前回処理した時の（現地）日時。</param>
+        /// <param name="days">指定した日時の日付。</param>
+        /// <param name="hours">指定した日時の時間。</param>
+        /// <param name="minutes">指定した日時の分。</param>
+        /// <param name="seconds">指定した日時の秒。</param>
+        /// <returns></returns>
+        public static bool IsCrossedMonth(DateTime prev, int days, int hours, int minutes, int seconds)
 		{
 
-			DateTime now = DateTime.Now;
+            DateTime now = GetJapanStandardTimeNow();
 
-			DateTime border = now.Subtract(new TimeSpan(now.Day, now.Hour, now.Minute, now.Second)).Add(new TimeSpan(days, hours, minutes, seconds) + GetTimeDifference());
+			DateTime border = now.Subtract(new TimeSpan(now.Day, now.Hour, now.Minute, now.Second)).Add(new TimeSpan(days, hours, minutes, seconds));
 			if (now < border)
 				border = border.AddMonths(-1);
 
-			return IsCrossed(prev, border);
+			return IsCrossed(GetJapanStandardTime(prev), border);
 		}
 
 
-		/// <summary>
-		/// 指定した日時をまたいでいるかを取得します。3ヵ月単位で処理されます。
-		/// </summary>
-		/// <param name="prev">前回処理した時の日時。</param>
-		/// <param name="monthes">指定した日時の月部分のオフセット[0-2]。0なら3,6,9,12月を示します。</param>
-		/// <param name="days">指定した日時の日付。</param>
-		/// <param name="hours">指定した日時の時間。</param>
-		/// <param name="minutes">指定した日時の分。</param>
-		/// <param name="seconds">指定した日時の秒。</param>
-		public static bool IsCrossedQuarter(DateTime prev, int monthes, int days, int hours, int minutes, int seconds)
+        /// <summary>
+        /// 指定した日時をまたいでいるかを取得します。3ヵ月単位で処理されます。
+        /// </summary>
+        /// <param name="prev">前回処理した時の（現地）日時。</param>
+        /// <param name="monthes">指定した日時の月部分のオフセット[0-2]。0なら3,6,9,12月を示します。</param>
+        /// <param name="days">指定した日時の日付。</param>
+        /// <param name="hours">指定した日時の時間。</param>
+        /// <param name="minutes">指定した日時の分。</param>
+        /// <param name="seconds">指定した日時の秒。</param>
+        public static bool IsCrossedQuarter(DateTime prev, int monthes, int days, int hours, int minutes, int seconds)
 		{
-			DateTime now = DateTime.Now;
+			DateTime now = GetJapanStandardTimeNow();
 			int targetMonth = now.Month / 3 * 3 + monthes;
-			DateTime border = new DateTime(now.Year - (targetMonth < 1 ? 1 : 0), targetMonth < 1 ? targetMonth + 12 : targetMonth, days, hours, minutes, seconds) + GetTimeDifference();
+			DateTime border = new DateTime(now.Year - (targetMonth < 1 ? 1 : 0), targetMonth < 1 ? targetMonth + 12 : targetMonth, days, hours, minutes, seconds);
 			if (now < border)
 				border = border.AddMonths(-3);
 
-			return IsCrossed(prev, border);
+			return IsCrossed(GetJapanStandardTime(prev), border);
 		}
 
 
@@ -255,15 +255,22 @@ namespace ElectronicObserver.Utility.Mathematics
 				elem.Length > 3 ? int.Parse(elem[3]) : 0,
 				elem.Length > 4 ? int.Parse(elem[4]) : 0,
 				elem.Length > 5 ? int.Parse(elem[5]) : 0);
-		}
+        }
 
+        /// <summary>
+        /// 現在の東京標準時を取得します。
+        /// </summary>
+        public static DateTime GetJapanStandardTimeNow()
+        {
+            return DateTime.UtcNow + new TimeSpan(9, 0, 0);
+        }
 
-		/// <summary>
-		/// 現在地点と東京標準時(艦これ時間)との時差を取得します。
-		/// </summary>
-		public static TimeSpan GetTimeDifference()
+        /// <summary>
+        /// 指定した日時の東京標準時を取得します。
+        /// </summary>
+        public static DateTime GetJapanStandardTime(DateTime time)
 		{
-			return TimeZoneInfo.Local.BaseUtcOffset - new TimeSpan(9, 0, 0);
+			return time - TimeZoneInfo.Local.BaseUtcOffset + new TimeSpan(9, 0, 0);
 		}
 
 

--- a/ElectronicObserver/Utility/Mathematics/DateTimeHelper.cs
+++ b/ElectronicObserver/Utility/Mathematics/DateTimeHelper.cs
@@ -123,15 +123,15 @@ namespace ElectronicObserver.Utility.Mathematics
 		}
 
 
-        /// <summary>
-        /// 指定した日時をまたいでいるかを取得します。日単位で処理されます。
-        /// </summary>
-        /// <param name="prev">前回処理した時の（現地）日時。</param>
-        /// <param name="hours">指定した日時の時間。</param>
-        /// <param name="minutes">指定した日時の分。</param>
-        /// <param name="seconds">指定した日時の秒。</param>
-        /// <returns></returns>
-        public static bool IsCrossedDay(DateTime prev, int hours, int minutes, int seconds)
+		/// <summary>
+		/// 指定した日時をまたいでいるかを取得します。日単位で処理されます。
+		/// </summary>
+		/// <param name="prev">前回処理した時の（現地）日時。</param>
+		/// <param name="hours">指定した日時の時間。</param>
+		/// <param name="minutes">指定した日時の分。</param>
+		/// <param name="seconds">指定した日時の秒。</param>
+		/// <returns></returns>
+		public static bool IsCrossedDay(DateTime prev, int hours, int minutes, int seconds)
 		{
 
 			DateTime now = GetJapanStandardTimeNow();
@@ -143,16 +143,16 @@ namespace ElectronicObserver.Utility.Mathematics
 		}
 
 
-        /// <summary>
-        /// 指定した日時をまたいでいるかを取得します。週単位で処理されます。
-        /// </summary>
-        /// <param name="prev">前回処理した時の（現地）日時。</param>
-        /// <param name="dayOfWeek">指定した日時の曜日。</param>
-        /// <param name="hours">指定した日時の時間。</param>
-        /// <param name="minutes">指定した日時の分。</param>
-        /// <param name="seconds">指定した日時の秒。</param>
-        /// <returns></returns>
-        public static bool IsCrossedWeek(DateTime prev, DayOfWeek dayOfWeek, int hours, int minutes, int seconds)
+		/// <summary>
+		/// 指定した日時をまたいでいるかを取得します。週単位で処理されます。
+		/// </summary>
+		/// <param name="prev">前回処理した時の（現地）日時。</param>
+		/// <param name="dayOfWeek">指定した日時の曜日。</param>
+		/// <param name="hours">指定した日時の時間。</param>
+		/// <param name="minutes">指定した日時の分。</param>
+		/// <param name="seconds">指定した日時の秒。</param>
+		/// <returns></returns>
+		public static bool IsCrossedWeek(DateTime prev, DayOfWeek dayOfWeek, int hours, int minutes, int seconds)
 		{
 
 			DateTime now = GetJapanStandardTimeNow();
@@ -172,19 +172,19 @@ namespace ElectronicObserver.Utility.Mathematics
 		}
 
 
-        /// <summary>
-        /// 指定した日時をまたいでいるかを取得します。月単位で処理されます。
-        /// </summary>
-        /// <param name="prev">前回処理した時の（現地）日時。</param>
-        /// <param name="days">指定した日時の日付。</param>
-        /// <param name="hours">指定した日時の時間。</param>
-        /// <param name="minutes">指定した日時の分。</param>
-        /// <param name="seconds">指定した日時の秒。</param>
-        /// <returns></returns>
-        public static bool IsCrossedMonth(DateTime prev, int days, int hours, int minutes, int seconds)
+		/// <summary>
+		/// 指定した日時をまたいでいるかを取得します。月単位で処理されます。
+		/// </summary>
+		/// <param name="prev">前回処理した時の（現地）日時。</param>
+		/// <param name="days">指定した日時の日付。</param>
+		/// <param name="hours">指定した日時の時間。</param>
+		/// <param name="minutes">指定した日時の分。</param>
+		/// <param name="seconds">指定した日時の秒。</param>
+		/// <returns></returns>
+		public static bool IsCrossedMonth(DateTime prev, int days, int hours, int minutes, int seconds)
 		{
 
-            DateTime now = GetJapanStandardTimeNow();
+			DateTime now = GetJapanStandardTimeNow();
 
 			DateTime border = now.Subtract(new TimeSpan(now.Day, now.Hour, now.Minute, now.Second)).Add(new TimeSpan(days, hours, minutes, seconds));
 			if (now < border)
@@ -194,16 +194,16 @@ namespace ElectronicObserver.Utility.Mathematics
 		}
 
 
-        /// <summary>
-        /// 指定した日時をまたいでいるかを取得します。3ヵ月単位で処理されます。
-        /// </summary>
-        /// <param name="prev">前回処理した時の（現地）日時。</param>
-        /// <param name="monthes">指定した日時の月部分のオフセット[0-2]。0なら3,6,9,12月を示します。</param>
-        /// <param name="days">指定した日時の日付。</param>
-        /// <param name="hours">指定した日時の時間。</param>
-        /// <param name="minutes">指定した日時の分。</param>
-        /// <param name="seconds">指定した日時の秒。</param>
-        public static bool IsCrossedQuarter(DateTime prev, int monthes, int days, int hours, int minutes, int seconds)
+		/// <summary>
+		/// 指定した日時をまたいでいるかを取得します。3ヵ月単位で処理されます。
+		/// </summary>
+		/// <param name="prev">前回処理した時の（現地）日時。</param>
+		/// <param name="monthes">指定した日時の月部分のオフセット[0-2]。0なら3,6,9,12月を示します。</param>
+		/// <param name="days">指定した日時の日付。</param>
+		/// <param name="hours">指定した日時の時間。</param>
+		/// <param name="minutes">指定した日時の分。</param>
+		/// <param name="seconds">指定した日時の秒。</param>
+		public static bool IsCrossedQuarter(DateTime prev, int monthes, int days, int hours, int minutes, int seconds)
 		{
 			DateTime now = GetJapanStandardTimeNow();
 			int targetMonth = now.Month / 3 * 3 + monthes;
@@ -255,20 +255,20 @@ namespace ElectronicObserver.Utility.Mathematics
 				elem.Length > 3 ? int.Parse(elem[3]) : 0,
 				elem.Length > 4 ? int.Parse(elem[4]) : 0,
 				elem.Length > 5 ? int.Parse(elem[5]) : 0);
-        }
+		}
 
-        /// <summary>
-        /// 現在の東京標準時を取得します。
-        /// </summary>
-        public static DateTime GetJapanStandardTimeNow()
-        {
-            return DateTime.UtcNow + new TimeSpan(9, 0, 0);
-        }
+		/// <summary>
+		/// 現在の東京標準時を取得します。
+		/// </summary>
+		public static DateTime GetJapanStandardTimeNow()
+		{
+			return DateTime.UtcNow + new TimeSpan(9, 0, 0);
+		}
 
-        /// <summary>
-        /// 指定した日時の東京標準時を取得します。
-        /// </summary>
-        public static DateTime GetJapanStandardTime(DateTime time)
+		/// <summary>
+		/// 指定した日時の東京標準時を取得します。
+		/// </summary>
+		public static DateTime GetJapanStandardTime(DateTime time)
 		{
 			return time - TimeZoneInfo.Local.BaseUtcOffset + new TimeSpan(9, 0, 0);
 		}

--- a/ElectronicObserver/Window/FormMain.cs
+++ b/ElectronicObserver/Window/FormMain.cs
@@ -326,7 +326,7 @@ namespace ElectronicObserver.Window
             SystemEvents.OnUpdateTimerTick();
 
             // 東京標準時
-            DateTime now = DateTime.UtcNow + new TimeSpan(9, 0, 0);
+            DateTime now = Utility.Mathematics.DateTimeHelper.GetJapanStandardTimeNow();
 
             switch (ClockFormat)
             {


### PR DESCRIPTION
Fix a bug that monthly/quarterly quests sometimes does not reset for a time zone that is more than 5 hours late than Japan.
日本より5時間以上遅いタイムゾーンでは、マンスリー/クォータリー任務がリセットされないことがあるバグを修正します。

The bug will happen when user refresh the quest list after new monthly quest refreshes but the local time is not yet in the new month. e.g. When Japan is 09/01 6:00 (monthly quest reset at 5:00), an user in UTF+0 will have local time 08/31 21:00, the previous algorithm will think the month is still 08 and set border time to be 07/31 20:00 (=08/01 5:00 Japan time) which is wrong. New algorithm will fix it as it convert all time to Japan time, no more local time.