### PR TITLE
Enhance remodeling tips in level panel

### DIFF
--- a/ElectronicObserver/Data/ShipData.cs
+++ b/ElectronicObserver/Data/ShipData.cs
@@ -496,6 +496,21 @@ namespace ElectronicObserver.Data
         }
 
 
+		/// <summary>
+		/// 最終改装まで必要な経験値
+		/// </summary>
+		public int ExpFinalRemodel
+		{
+			get
+			{
+				ShipDataMaster master = MasterShip;
+				if (master.FinalRemodelShipID <= 0)
+					return 0;
+				return Math.Max(ExpTable.ShipExp[master.FinalRemodelLevel].Total - ExpTotal, 0);
+			}
+		}
+
+
         /// <summary>
         /// 艦名
         /// </summary>

--- a/ElectronicObserver/Window/FormFleet.cs
+++ b/ElectronicObserver/Window/FormFleet.cs
@@ -504,17 +504,36 @@ namespace ElectronicObserver.Window
 						if (!Utility.Configuration.Config.FormFleet.ShowNextExp)
 							tip.AppendFormat("次のレベルまで: {0} exp.\r\n", ship.ExpNext);
 
-						if (ship.MasterShip.RemodelAfterShipID != 0 && ship.Level < ship.MasterShip.RemodelAfterLevel)
+						if (ship.MasterShip.RemodelAfterShipID != 0 && ship.MasterShip.RemodelAfterShipID != ship.MasterShip.FinalRemodelShipID && ship.Level < ship.MasterShip.RemodelAfterLevel)
 						{
 							tip.AppendFormat("改装まで: Lv. {0} / {1} exp.\r\n", ship.MasterShip.RemodelAfterLevel - ship.Level, ship.ExpNextRemodel);
 						}
-						else if (ship.Level <= 99)
+						else if (ship.MasterShip != ship.MasterShip.FinalRemodelShip && ship.Level < ship.MasterShip.FinalRemodelLevel)
 						{
-							tip.AppendFormat("Lv99まで: {0} exp.\r\n", Math.Max(ExpTable.GetExpToLevelShip(ship.ExpTotal, 99), 0));
+							if (ship.MasterShip.RemodelAfterShipID != ship.MasterShip.FinalRemodelShipID)
+							{
+								tip.Append("今改装可能.\r\n");
+							}
+							tip.AppendFormat("最終改装まで: Lv. {0} / {1} exp.\r\n", ship.MasterShip.FinalRemodelLevel - ship.Level, ship.ExpFinalRemodel);
 						}
 						else
 						{
-							tip.AppendFormat("Lv{0}まで: {1} exp.\r\n", ExpTable.ShipMaximumLevel, Math.Max(ExpTable.GetExpToLevelShip(ship.ExpTotal, ExpTable.ShipMaximumLevel), 0));
+							if (ship.ShipID != ship.MasterShip.FinalRemodelShipID)
+							{
+								tip.Append("今最終改装可能.\r\n");
+							}
+							else if  (ship.MasterShip.CanConvertRemodel)
+							{
+								tip.Append("今コンバート改装可能.\r\n");
+							}
+							if (ship.Level <= 99)
+							{
+								tip.AppendFormat("Lv99まで: {0} exp.\r\n", Math.Max(ExpTable.GetExpToLevelShip(ship.ExpTotal, 99), 0));
+							}
+							else
+							{
+								tip.AppendFormat("Lv{0}まで: {1} exp.\r\n", ExpTable.ShipMaximumLevel, Math.Max(ExpTable.GetExpToLevelShip(ship.ExpTotal, ExpTable.ShipMaximumLevel), 0));
+							}
 						}
 
 						tip.AppendLine("(右クリックで必要Exp計算)");


### PR DESCRIPTION
Add an additional tips to inform if a ship can  be remodeled to final stage, which takes the largest level.

I think it's convenient for those leveling backup ships.

![1](https://user-images.githubusercontent.com/8273026/65366457-bac0b380-dc56-11e9-9f3a-afb9c2ed5c6c.jpg)

![2](https://user-images.githubusercontent.com/8273026/65366462-c90ecf80-dc56-11e9-9ea8-0b04b176909a.jpg)

![3](https://user-images.githubusercontent.com/8273026/65366465-cdd38380-dc56-11e9-9edb-a467e0d1e57a.jpg)

![4](https://user-images.githubusercontent.com/8273026/65366468-d3c96480-dc56-11e9-9412-c1c472649285.jpg)

![5](https://user-images.githubusercontent.com/8273026/65366470-d926af00-dc56-11e9-82cb-7c6ae81fd34e.jpg)

![6](https://user-images.githubusercontent.com/8273026/65366471-ddeb6300-dc56-11e9-97f3-cac322af116e.jpg)
