### PR TITLE
日向改二の先制対潜条件の修正／Janus改の自動先制対潜への対応

### DIFF
--- a/ElectronicObserver/Data/ShipData.cs
+++ b/ElectronicObserver/Data/ShipData.cs
@@ -1368,6 +1368,7 @@ namespace ElectronicObserver.Data
                     case 689:       // Johnston改
                     case 596:       // Fletcher
                     case 692:       // Fletcher改
+                    case 893:       // Janus改
                         return true;
                 }
 
@@ -1383,10 +1384,10 @@ namespace ElectronicObserver.Data
 
                     case 554:   // 日向改二
                         // カ号観測機, オ号観測機改, オ号観測機改二
-                        if (eqs.Any(eq => eq.EquipmentID == 69 || eq.EquipmentID == 324 || eq.EquipmentID == 325))
+                        if (eqs.Count(eq => eq.EquipmentID == 69 || eq.EquipmentID == 324 || eq.EquipmentID == 325) >= 2)
                             return true;
                         // S-51J, S-51J改
-                        if (eqs.Count(eq => eq.EquipmentID == 326) >= 2 || eqs.Count(eq => eq.EquipmentID == 327) >= 2)
+                        if (eqs.Any(eq => eq.EquipmentID == 326 || eq.EquipmentID == 327))
                             return true;
 
                         return false;


### PR DESCRIPTION
1. 日向改二の先制対潜条件を「回転翼機（カ号観測機, オ号観測機改, オ号観測機改二）の合計が2個以上」もしくは「対潜ヘリ（S-51J, S-51J改）が1個以上」に修正

1. Jervis改と同様にJanus改を無条件で先制対潜可能と判定するように変更