### PR TITLE
Don't throw NullReferenceException during handling of CommunicationException

### DIFF
--- a/BrowserLib/PipeCommunicator.cs
+++ b/BrowserLib/PipeCommunicator.cs
@@ -116,7 +116,7 @@ namespace BrowserLib
 					}
 					catch (CommunicationException cex)
 					{
-						((IClientChannel)Proxy).Abort();
+						((IClientChannel)Proxy)?.Abort();
 						Proxy = null;
 						if (i >= 1)
 						{

--- a/ElectronicObserver/Window/FormBrowserHost.cs
+++ b/ElectronicObserver/Window/FormBrowserHost.cs
@@ -493,7 +493,7 @@ namespace ElectronicObserver.Window
 		{
 			if (Browser.Proxy == null)
 			{
-				Utility.Logger.Add(3, "ブラウザプロセスが予期せず終了しました。");
+				Utility.ErrorReporter.SendErrorReport(e, "ブラウザプロセスが予期せず終了しました。");
 			}
 			else
 			{


### PR DESCRIPTION
Also made sure to generate an error report if Browser connection fails at startup time.

In some cases we see `ブラウザプロセスが予期せず終了しました。` immediately after startup, but the Browser is actually running and one can even continue using it without problem. It seems to happen more often when EO is compiled in release mode.

After fixing this retry logic I cannot reproduce it anymore. Likely this is because of some race condition, which I am too lazy to dig in...