### PR TITLE
Implement a function to copy selected lines in Log

### DIFF
--- a/ElectronicObserver/Window/FormLog.Designer.cs
+++ b/ElectronicObserver/Window/FormLog.Designer.cs
@@ -31,15 +31,14 @@
 			this.components = new System.ComponentModel.Container();
 			this.LogList = new System.Windows.Forms.ListBox();
 			this.ContextMenuLog = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.ContextMenuLog_Copy = new System.Windows.Forms.ToolStripMenuItem();
 			this.ContextMenuLog_Clear = new System.Windows.Forms.ToolStripMenuItem();
 			this.ContextMenuLog.SuspendLayout();
 			this.SuspendLayout();
 			// 
 			// LogList
 			// 
-			this.LogList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-			| System.Windows.Forms.AnchorStyles.Left)
-			| System.Windows.Forms.AnchorStyles.Right)));
+			this.LogList.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
 			this.LogList.BackColor = System.Drawing.SystemColors.Control;
 			this.LogList.BorderStyle = System.Windows.Forms.BorderStyle.None;
 			this.LogList.ContextMenuStrip = this.ContextMenuLog;
@@ -49,22 +48,29 @@
 			this.LogList.ItemHeight = 15;
 			this.LogList.Location = new System.Drawing.Point(0, 0);
 			this.LogList.Name = "LogList";
-			this.LogList.SelectionMode = System.Windows.Forms.SelectionMode.None;
+			this.LogList.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
 			this.LogList.Size = new System.Drawing.Size(300, 200);
 			this.LogList.TabIndex = 0;
+			this.LogList.KeyDown += new System.Windows.Forms.KeyEventHandler(this.LogList_KeyDown);
 			// 
 			// ContextMenuLog
 			// 
-			this.ContextMenuLog.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ContextMenuLog_Clear});
+			this.ContextMenuLog.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {this.ContextMenuLog_Copy, this.ContextMenuLog_Clear});
 			this.ContextMenuLog.Name = "ContextMenuLog";
-			this.ContextMenuLog.Size = new System.Drawing.Size(131, 26);
+			this.ContextMenuLog.Size = new System.Drawing.Size(121, 48);
+			// 
+			// ContextMenuLog_Copy
+			// 
+			this.ContextMenuLog_Copy.Name = "ContextMenuLog_Copy";
+			this.ContextMenuLog_Copy.Size = new System.Drawing.Size(120, 22);
+			this.ContextMenuLog_Copy.Text = "コピー(&C)";
+			this.ContextMenuLog_Copy.Click += new System.EventHandler(this.ContextMenuLog_Copy_Click);
 			// 
 			// ContextMenuLog_Clear
 			// 
 			this.ContextMenuLog_Clear.Name = "ContextMenuLog_Clear";
-			this.ContextMenuLog_Clear.Size = new System.Drawing.Size(152, 22);
-			this.ContextMenuLog_Clear.Text = "クリア(&C)";
+			this.ContextMenuLog_Clear.Size = new System.Drawing.Size(120, 22);
+			this.ContextMenuLog_Clear.Text = "クリア(&R)";
 			this.ContextMenuLog_Clear.Click += new System.EventHandler(this.ContextMenuLog_Clear_Click);
 			// 
 			// FormLog
@@ -82,13 +88,13 @@
 			this.Load += new System.EventHandler(this.FormLog_Load);
 			this.ContextMenuLog.ResumeLayout(false);
 			this.ResumeLayout(false);
-
 		}
 
 		#endregion
 
 		private System.Windows.Forms.ListBox LogList;
 		private System.Windows.Forms.ContextMenuStrip ContextMenuLog;
+		private System.Windows.Forms.ToolStripMenuItem ContextMenuLog_Copy;
 		private System.Windows.Forms.ToolStripMenuItem ContextMenuLog_Clear;
 
 	}

--- a/ElectronicObserver/Window/FormLog.cs
+++ b/ElectronicObserver/Window/FormLog.cs
@@ -71,6 +71,29 @@ namespace ElectronicObserver.Window
 		}
 
 
+		private void CopyToClipboard()
+		{
+			if (LogList.SelectedItems.Count > 0)
+			{
+				Clipboard.SetText(string.Join("\n", LogList.SelectedItems.Cast<string>()));
+			}
+		}
+
+
+		private void LogList_KeyDown(object sender, KeyEventArgs e)
+		{
+			if (e.Control && e.KeyCode == Keys.C)
+			{
+				CopyToClipboard();
+			}
+		}
+
+
+		private void ContextMenuLog_Copy_Click(object sender, EventArgs e)
+		{
+			CopyToClipboard();
+		}
+
 
 		private void ContextMenuLog_Clear_Click(object sender, EventArgs e)
 		{


### PR DESCRIPTION
This can be triggered from a context menu item, or by pressing Ctrl+C.

It changes the behavior of the ListBox to allow users to select multiple lines at the same time. It causes a minor UI change too (as the lines will now be highlighted on selection, and there is no way to unselect it).