### PR TITLE
砲撃、雷撃、対潜、航空攻撃、夜戦のキャップ更新

### DIFF
--- a/ElectronicObserver/Data/ShipData.cs
+++ b/ElectronicObserver/Data/ShipData.cs
@@ -990,7 +990,7 @@ namespace ElectronicObserver.Data
             }
 
             //キャップ
-            basepower = Math.Floor(CapDamage(basepower, 150));
+            basepower = Math.Floor(CapDamage(basepower, 170));
 
             return (int)(basepower * GetAmmoDamageRate());
         }
@@ -1013,7 +1013,7 @@ namespace ElectronicObserver.Data
             basepower += GetLightCruiserDamageBonus() + GetItalianDamageBonus();
 
             // キャップ
-            basepower = Math.Floor(CapDamage(basepower, 180));
+            basepower = Math.Floor(CapDamage(basepower, 220));
 
             // 弾着観測射撃
             switch (attackKind)
@@ -1058,7 +1058,7 @@ namespace ElectronicObserver.Data
             basepower *= GetHPDamageBonus() * GetEngagementFormDamageRate(engagementForm);
 
             // キャップ
-            basepower = Math.Floor(CapDamage(basepower, 180));
+            basepower = Math.Floor(CapDamage(basepower, 220));
 
 
             // 空母カットイン
@@ -1166,7 +1166,7 @@ namespace ElectronicObserver.Data
 
 
             //キャップ
-            basepower = Math.Floor(CapDamage(basepower, 150));
+            basepower = Math.Floor(CapDamage(basepower, 170));
 
             return (int)(basepower * GetAmmoDamageRate());
         }
@@ -1185,7 +1185,7 @@ namespace ElectronicObserver.Data
             basepower *= GetTorpedoHPDamageBonus() * GetEngagementFormDamageRate(engagementForm);
 
             //キャップ
-            basepower = Math.Floor(CapDamage(basepower, 150));
+            basepower = Math.Floor(CapDamage(basepower, 180));
 
 
             return (int)(basepower * GetAmmoDamageRate());
@@ -1312,7 +1312,7 @@ namespace ElectronicObserver.Data
             basepower += GetLightCruiserDamageBonus() + GetItalianDamageBonus();
 
             //キャップ
-            basepower = Math.Floor(CapDamage(basepower, 300));
+            basepower = Math.Floor(CapDamage(basepower, 360));
 
 
             return (int)(basepower * GetAmmoDamageRate());


### PR DESCRIPTION
ソース：https://twitter.com/nishikkuma/status/1366364071193309185?s=20

昼砲撃戦キャップ：220
昼雷撃戦キャップ：180
夜戦キャップ：360
対潜キャップ：170
航空戦キャップ：170
支援キャップ：170